### PR TITLE
[18.0][FIX] shopfloor: fix action `stock.mark_move_line_as_picked`

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -126,11 +126,12 @@ class StockAction(Component):
                     _("Someone is already working on these transfers")
                 )
         for line in move_lines:
+            qty_picked = quantity if quantity is not None else line.quantity
+            line.qty_picked = qty_picked
             if split:
                 line._split_partial_quantity()
             data = {
                 "shopfloor_user_id": user.id,
-                "qty_picked": quantity or line.quantity,
             }
             if package:
                 # destination package is set to the scanned one


### PR DESCRIPTION
Restore the 16.0 code and replace `qty_done` by `qty_picked`. 

This regression was introduced initially in:
- https://github.com/OCA/stock-logistics-shopfloor/pull/2

And badly fixed there:
- https://github.com/OCA/stock-logistics-shopfloor/pull/15

We should be able to call `mark_move_line_as_picked` with `quantity=0` (as done in `location_content_transfer` scenario for instance) to unpick the goods.