### PR TITLE
[18.0][MIG] shopfloor: migrate `location_content_transfer` scenario

### DIFF
--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -186,7 +186,7 @@ class LocationContentTransfer(Component):
             self._domain_recover_pickings()
         )
         started_pickings = candidate_pickings.filtered(
-            lambda picking: any(line.qty_done for line in picking.move_line_ids)
+            lambda picking: any(line.picked for line in picking.move_line_ids)
         )
         return started_pickings
 
@@ -416,8 +416,7 @@ class LocationContentTransfer(Component):
         return [
             ("location_id", "=", location.id),
             ("state", "in", ("assigned", "partially_available")),
-            ("qty_done", ">", 0),
-            # TODO check generated SQL
+            ("picked", "=", True),
             ("picking_id.user_id", "=", self.env.uid),
         ]
 
@@ -431,7 +430,7 @@ class LocationContentTransfer(Component):
     # hook used in module shopfloor_checkout_sync
     def _write_destination_on_lines(self, lines, location):
         lines.location_dest_id = location
-        lines.package_level_id.picking_id.location_dest_id = location
+        lines.package_level_id.location_dest_id = location
 
     def _set_all_destination_lines_and_done(self, pickings, move_lines, dest_location):
         self._write_destination_on_lines(move_lines, dest_location)
@@ -762,7 +761,7 @@ class LocationContentTransfer(Component):
 
         self._lock_lines(move_line)
 
-        move_line.qty_done = quantity
+        move_line.qty_picked = quantity
         self._write_destination_on_lines(move_line, scanned_location)
 
         stock = self._actions_for("stock")
@@ -770,7 +769,7 @@ class LocationContentTransfer(Component):
         backorders = stock.validate_moves(move_line.move_id)
         if backorders:
             for move_line in backorders.mapped("move_line_ids"):
-                move_line.qty_done = move_line.quantity
+                move_line.picked = True
             backorders.user_id = self.env.user
             # process first backorder of current line
             move_lines = backorders.move_line_ids
@@ -858,9 +857,8 @@ class LocationContentTransfer(Component):
             # split the move to process only the lines related to the package.
             package_move.split_other_move_lines(package_move_lines)
             lot = package_move.move_line_ids.lot_id
-            # We need to set qty_done at 0 because otherwise
-            # the move_line will not be deleted
-            package_move.move_line_ids.write({"qty_done": 0})
+            # We need to unpick the line because otherwise it won't be deleted
+            package_move.move_line_ids.picked = False
             package = package_level.package_id
             if (
                 self.is_allow_move_create()
@@ -912,9 +910,8 @@ class LocationContentTransfer(Component):
         move = move_line.move_id
         package = move_line.package_id
         lot = move_line.lot_id
-        # We need to set qty_done at 0 because otherwise
-        # the move_line will not be deleted
-        move_line.qty_done = 0
+        # We need to unpick the line because otherwise it won't be deleted
+        move_line.picked = False
         if self.is_allow_move_create() and self.env.user == move.picking_id.create_uid:
             # Owned by the user deleting the move
             move._action_cancel()
@@ -1072,7 +1069,7 @@ class ShopfloorLocationContentTransferValidatorResponse(Component):
         """
         return {
             "start": {},
-            "scan_location": {},
+            "scan_location": self._schema_scan_location,
             "get_work": {},
             "scan_destination_all": self._schema_all,
             "start_single": self._schema_single,
@@ -1109,6 +1106,15 @@ class ShopfloorLocationContentTransferValidatorResponse(Component):
                 "nullable": True,
                 "required": False,
             },
+        }
+
+    @property
+    def _schema_scan_location(self):
+        return {
+            "location": self.schemas._schema_dict_of(
+                self.schemas.location(),
+                required=False,
+            ),
         }
 
     def start_or_recover(self):
@@ -1204,4 +1210,17 @@ class ShopfloorLocationContentTransferValidatorResponse(Component):
     def dismiss_package_level(self):
         return self._response_schema(
             next_states={"scan_location", "get_work", "start_single"}
+        )
+
+    def cancel_work(self):
+        return self._response_schema(next_states={"scan_location", "get_work"})
+
+    def find_work(self):
+        return self._response_schema(
+            next_states={
+                "scan_location",
+                "get_work",
+                "scan_destination_all",
+                "start_single",
+            }
         )

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -54,16 +54,15 @@ from . import test_delivery_set_qty_done_line
 from . import test_delivery_sublocation
 from . import test_delivery_list_stock_picking
 from . import test_delivery_select
-
-# from . import test_location_content_transfer_base
-# from . import test_location_content_transfer_start
-# from . import test_location_content_transfer_get_work
-# from . import test_location_content_transfer_set_destination_all
-# from . import test_location_content_transfer_scan_location
-# from . import test_location_content_transfer_single
-# from . import test_location_content_transfer_set_destination_package_or_line
-# from . import test_location_content_transfer_putaway
-# from . import test_location_content_transfer_mix
+from . import test_location_content_transfer_base
+from . import test_location_content_transfer_start
+from . import test_location_content_transfer_get_work
+from . import test_location_content_transfer_set_destination_all
+from . import test_location_content_transfer_scan_location
+from . import test_location_content_transfer_single
+from . import test_location_content_transfer_set_destination_package_or_line
+from . import test_location_content_transfer_putaway
+from . import test_location_content_transfer_mix
 from . import test_zone_picking_base
 from . import test_zone_picking_complete_mix_pack_flux
 from . import test_zone_picking_start

--- a/shopfloor/tests/test_location_content_transfer_base.py
+++ b/shopfloor/tests/test_location_content_transfer_base.py
@@ -89,12 +89,11 @@ class LocationContentTransferCommonCase(CommonCase):
         It means a user scanned the location with the pickings. They are:
 
         * assigned to the user
-        * the qty_done of all their move lines is set to they reserved qty
+        * all reserved qty are picked
 
         """
         pickings.user_id = cls.env.uid
-        for line in pickings.mapped("move_line_ids"):
-            line.qty_done = line.quantity
+        pickings.move_line_ids.picked = True
 
     def assert_response_start(self, response, message=None, popup=None):
         self.assert_response(

--- a/shopfloor/tests/test_location_content_transfer_get_work.py
+++ b/shopfloor/tests/test_location_content_transfer_get_work.py
@@ -23,7 +23,7 @@ class TestLocationContentTransferGetWork(LocationContentTransferCommonCase):
             [("location_id", "=", cls.stock_location.id)]
         )
         cls.move_lines = cls.pickings.move_line_ids.filtered(
-            lambda line: line.qty_done == 0
+            lambda line: not line.picked
             and line.state in ("assigned", "partially_available")
             and not line.shopfloor_user_id
         )

--- a/shopfloor/tests/test_location_content_transfer_mix.py
+++ b/shopfloor/tests/test_location_content_transfer_mix.py
@@ -80,13 +80,39 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
                 "warehouse_id": cls.wh.id,
                 "picking_type_id": cls.wh.out_type_id.id,
                 "procure_method": "make_to_order",
-                "state": "draft",
+                "state": "waiting",
             }
         )
-        cls.ship_move_a._assign_picking()
-        cls.ship_move_a._action_confirm()
-        cls.pack_move_a = cls.ship_move_a.move_orig_ids[0]
-        cls.pick_move_a = cls.pack_move_a.move_orig_ids[0]
+        cls.pack_move_a = cls.env["stock.move"].create(
+            {
+                "name": cls.product_a.display_name,
+                "product_id": cls.product_a.id,
+                "product_uom_qty": 10.0,
+                "product_uom": cls.product_a.uom_id.id,
+                "location_id": cls.pack_location.id,
+                "location_dest_id": cls.ship_location.id,
+                "warehouse_id": cls.wh.id,
+                "picking_type_id": cls.wh.pack_type_id.id,
+                "procure_method": "make_to_order",
+                "move_dest_ids": [(4, cls.ship_move_a.id)],
+                "state": "waiting",
+            }
+        )
+        cls.pick_move_a = cls.env["stock.move"].create(
+            {
+                "name": cls.product_a.display_name,
+                "product_id": cls.product_a.id,
+                "product_uom_qty": 10.0,
+                "product_uom": cls.product_a.uom_id.id,
+                "location_id": cls.stock_location.id,
+                "location_dest_id": cls.pack_location.id,
+                "warehouse_id": cls.wh.id,
+                "picking_type_id": cls.wh.pick_type_id.id,
+                "move_dest_ids": [(4, cls.pack_move_a.id)],
+                "state": "confirmed",
+            }
+        )
+        (cls.ship_move_a | cls.pack_move_a | cls.pick_move_a)._assign_picking()
         cls.picking1 = cls.pick_move_a.picking_id
         cls.packing1 = cls.pack_move_a.picking_id
         cls.picking1.action_assign()
@@ -177,7 +203,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
                 )
                 assert response["message"]["message_type"] == "success"
                 assert move_line.state == "done"
-                assert move_line.qty_done == qty
+                assert move_line.qty_picked == qty
         return response
 
     def test_with_zone_picking1(self):
@@ -306,12 +332,12 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             lambda x: not x.shopfloor_user_id and x.location_id == dest_location1
         )
         self.assertEqual(pack_first_pallet.quantity, 6)
-        self.assertEqual(pack_first_pallet.qty_done, 0)
+        self.assertEqual(pack_first_pallet.qty_picked, 0)
         pack_second_pallet = pack_move_a.move_line_ids.filtered(
             lambda x: not x.shopfloor_user_id and x.location_id == dest_location2
         )
         self.assertEqual(pack_second_pallet.quantity, 4)
-        self.assertEqual(pack_second_pallet.qty_done, 0)
+        self.assertEqual(pack_second_pallet.qty_picked, 0)
         # Operator-2 with the "location content transfer" scenario scan
         # the location where the first pallet is.
         # This pallet/move line will be put in its own transfer as its sibling
@@ -327,7 +353,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             response_packages[0]["package_src"]["id"], pack_first_pallet.package_id.id
         )
         # Ensure that the second pallet is untouched
-        self.assertEqual(pack_second_pallet.qty_done, 0)
+        self.assertEqual(pack_second_pallet.qty_picked, 0)
         # Operator-3 with the "location content transfer" scenario scan
         # the location where the first pallet is: he should found nothing
         response = self._location_content_transfer_process_line(
@@ -356,11 +382,11 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
                 pack_first_pallet.location_dest_id,
             ),
         )
-        self.assertEqual(pack_first_pallet.qty_done, 6)
+        self.assertEqual(pack_first_pallet.qty_picked, 6)
         self.assertEqual(pack_first_pallet.state, "done")
         self.assertEqual(pack_first_pallet.move_id.product_uom_qty, qty)
         # Ensure that the second pallet is untouched
-        self.assertEqual(pack_second_pallet.qty_done, 0)
+        self.assertEqual(pack_second_pallet.qty_picked, 0)
         # Operator-2 (still with the "location content transfer" scenario) scan
         # the location where the second pallet is
         pack_move_a = pick_move_line2.move_id.move_dest_ids.filtered(
@@ -447,7 +473,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             lambda x: not x.shopfloor_user_id and x.location_id == dest_location1
         )
         self.assertEqual(pack_first_pallet.quantity, 6)
-        self.assertEqual(pack_first_pallet.qty_done, 0)
+        self.assertEqual(pack_first_pallet.qty_picked, 0)
         # Operator-2 with the "location content transfer" scenario scan
         # the location where the first pallet is.
         # This pallet/move line will be put in its own move and transfer by convenience
@@ -473,7 +499,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
             lambda x: not x.shopfloor_user_id and x.location_id == dest_location2
         )
         self.assertEqual(pack_second_pallet.quantity, 4)
-        self.assertEqual(pack_second_pallet.qty_done, 0)
+        self.assertEqual(pack_second_pallet.qty_picked, 0)
         # The last action has updated the pack operation (new move line) in the
         # transfer previously processed by Operator-2.
         self.assertEqual(original_pack_transfer.state, "assigned")
@@ -492,7 +518,7 @@ class LocationContentTransferMixCase(LocationContentTransferCommonCase):
                 pack_first_pallet.location_dest_id,
             ),
         )
-        self.assertEqual(pack_first_pallet.qty_done, 6)
+        self.assertEqual(pack_first_pallet.qty_picked, 6)
         self.assertEqual(pack_first_pallet.state, "done")
         self.assertEqual(pack_first_pallet.move_id.product_uom_qty, qty)
         # Operator-2 with the "location content transfer" scenario scan

--- a/shopfloor/tests/test_location_content_transfer_set_destination_all.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_all.py
@@ -47,10 +47,26 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
         self.assertRecordValues(
             self.pickings.move_line_ids,
             [
-                {"qty_done": 10.0, "state": "done", "location_dest_id": destination.id},
-                {"qty_done": 10.0, "state": "done", "location_dest_id": destination.id},
-                {"qty_done": 10.0, "state": "done", "location_dest_id": destination.id},
-                {"qty_done": 10.0, "state": "done", "location_dest_id": destination.id},
+                {
+                    "qty_picked": 10.0,
+                    "state": "done",
+                    "location_dest_id": destination.id,
+                },
+                {
+                    "qty_picked": 10.0,
+                    "state": "done",
+                    "location_dest_id": destination.id,
+                },
+                {
+                    "qty_picked": 10.0,
+                    "state": "done",
+                    "location_dest_id": destination.id,
+                },
+                {
+                    "qty_picked": 10.0,
+                    "state": "done",
+                    "location_dest_id": destination.id,
+                },
             ],
         )
         self.assertRecordValues(
@@ -91,6 +107,7 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
         the current pickings is validated.
         """
         # Put a partial quantity for 'product_d' to get a partially available move
+        self.picking2.move_line_ids.picked = False
         self.picking2.do_unreserve()
         self._update_qty_in_location(self.content_loc, self.product_d, 5)
         self.picking2.action_assign()
@@ -138,6 +155,7 @@ class LocationContentTransferSetDestinationAllCase(LocationContentTransferCommon
         remaining qties stay in their current picking.
         """
         # Put a partial quantity for 'product_d' to get a partially available move
+        self.picking2.move_line_ids.picked = False
         self.picking2.do_unreserve()
         self._update_qty_in_location(self.content_loc, self.product_d, 5)
         self.picking2.action_assign()

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -568,7 +568,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         )
         done_picking = picking
         # Check move line data
-        self.assertEqual(move_line.move_id.product_uom_qty, 6)
+        self.assertEqual(move_line.move_id.product_uom_qty, 10)
         self.assertEqual(move_line.quantity, 6)
         self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
@@ -612,7 +612,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         # 2 operations then the done operation is set into a specific picking
         first_done_picking = picking.backorder_ids
         # Check move line data
-        self.assertEqual(move_line.move_id.product_uom_qty, 6)
+        self.assertEqual(move_line.move_id.product_uom_qty, 10)
         self.assertEqual(move_line.quantity, 6)
         self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
@@ -639,7 +639,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
 
         # the initial picking should be done
         # Check move line data
-        self.assertEqual(move_line.move_id.product_uom_qty, 6)
+        self.assertEqual(move_line.move_id.product_uom_qty, 10)
         self.assertEqual(move_line.quantity, 6)
         self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")

--- a/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
+++ b/shopfloor/tests/test_location_content_transfer_set_destination_package_or_line.py
@@ -450,7 +450,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             lambda m: m.product_id == self.product_c
         )
         self.assertEqual(move_line_c.quantity, 10)
-        self.assertEqual(move_line_c.qty_done, 10)
+        self.assertEqual(move_line_c.qty_picked, 10)
         self._simulate_selected_move_line(move_line_c)
         # Scan partial qty (6/10)
         response = self.service.dispatch(
@@ -465,8 +465,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         done_picking = original_picking.backorder_ids
         # Check move line data
         self.assertEqual(move_line_c.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line_c.quantity, 0)
-        self.assertEqual(move_line_c.qty_done, 6)
+        self.assertEqual(move_line_c.quantity, 6)
+        self.assertEqual(move_line_c.qty_picked, 6)
         self.assertEqual(move_line_c.state, "done")
         self.assertEqual(original_picking.backorder_ids, done_picking)
         self.assertEqual(done_picking.state, "done")
@@ -479,7 +479,7 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         self.assertEqual(move.product_id, self.product_c)
         self.assertEqual(move.product_uom_qty, 4)
         self.assertEqual(move.move_line_ids.quantity, 4)
-        self.assertEqual(move.move_line_ids.qty_done, 4)
+        self.assertEqual(move.move_line_ids.qty_picked, 4)
         # Check the response -> we must first process the backorder
         self.assert_response_start_single(
             response,
@@ -504,8 +504,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         done_picking2 = remaining_move_line_c.picking_id
         # Check move line data
         self.assertEqual(remaining_move_line_c.move_id.product_uom_qty, 4)
-        self.assertEqual(remaining_move_line_c.quantity, 0)
-        self.assertEqual(remaining_move_line_c.qty_done, 4)
+        self.assertEqual(remaining_move_line_c.quantity, 4)
+        self.assertEqual(remaining_move_line_c.qty_picked, 4)
         self.assertEqual(remaining_move_line_c.state, "done")
         self.assertTrue(done_picking2 != original_picking)
         self.assertEqual(done_picking2.state, "done")
@@ -536,8 +536,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
             },
         )
         self.assertEqual(move_line_d.move_id.product_uom_qty, 10)
-        self.assertEqual(move_line_d.quantity, 0)
-        self.assertEqual(move_line_d.qty_done, 10)
+        self.assertEqual(move_line_d.quantity, 10)
+        self.assertEqual(move_line_d.qty_picked, 10)
         self.assertEqual(move_line_d.state, "done")
         self.assertEqual(original_picking.state, "done")
 
@@ -569,8 +569,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         done_picking = picking
         # Check move line data
         self.assertEqual(move_line.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line.quantity, 0)
-        self.assertEqual(move_line.qty_done, 6)
+        self.assertEqual(move_line.quantity, 6)
+        self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
         self.assertEqual(done_picking.state, "done")
 
@@ -613,8 +613,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         first_done_picking = picking.backorder_ids
         # Check move line data
         self.assertEqual(move_line.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line.quantity, 0)
-        self.assertEqual(move_line.qty_done, 6)
+        self.assertEqual(move_line.quantity, 6)
+        self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
         self.assertEqual(first_done_picking.state, "done")
 
@@ -640,8 +640,8 @@ class LocationContentTransferSetDestinationXCase(LocationContentTransferCommonCa
         # the initial picking should be done
         # Check move line data
         self.assertEqual(move_line.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line.quantity, 0)
-        self.assertEqual(move_line.qty_done, 6)
+        self.assertEqual(move_line.quantity, 6)
+        self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
         self.assertEqual(picking.state, "done")
 
@@ -784,8 +784,8 @@ class LocationContentTransferSetDestinationXSpecialCase(
         self.assertEqual(done_picking.state, "done")
         self.assertEqual(original_picking.state, "assigned")
         self.assertEqual(move_line.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line.quantity, 0)
-        self.assertEqual(move_line.qty_done, 6)
+        self.assertEqual(move_line.quantity, 6)
+        self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.location_dest_id, self.dest_location)
         self.assertEqual(len(original_picking.move_ids), 2)
         moves_product_b = original_picking.move_ids.filtered(
@@ -805,7 +805,7 @@ class LocationContentTransferSetDestinationXSpecialCase(
         self.assertEqual(remaining_move.state, "assigned")
         self.assertEqual(remaining_move.product_uom_qty, 4)
         self.assertEqual(remaining_move.move_line_ids.quantity, 4)
-        self.assertEqual(remaining_move.move_line_ids.qty_done, 4)
+        self.assertEqual(remaining_move.move_line_ids.qty_picked, 4)
         # Check the response
         move_lines = self.service._find_transfer_move_lines(self.content_loc)
         self.assert_response_start_single(
@@ -893,7 +893,7 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         """
         picking_a = self.picking_a
         picking_b = self.picking_b
-        picking_a.move_line_ids.qty_done = 10
+        picking_a.move_line_ids.qty_picked = 10
         picking_a._action_done()
         self.assertEqual(picking_a.state, "done")
         self.assertEqual(picking_b.state, "assigned")
@@ -904,7 +904,7 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         )
 
         self.assertEqual(move_line_c.quantity, 10)
-        self.assertEqual(move_line_c.qty_done, 10)
+        self.assertEqual(move_line_c.qty_picked, 10)
         # Scan partial qty (6/10)
         self.service.dispatch(
             "set_destination_line",
@@ -917,8 +917,8 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         )
         # Check move line data
         self.assertEqual(move_line_c.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line_c.quantity, 0)
-        self.assertEqual(move_line_c.qty_done, 6)
+        self.assertEqual(move_line_c.quantity, 6)
+        self.assertEqual(move_line_c.qty_picked, 6)
         self.assertEqual(move_line_c.state, "done")
         # the move has been split
         move = move_line_c.picking_id.backorder_ids.move_ids
@@ -929,7 +929,7 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         move_line = move.move_line_ids
         self.assertEqual(move_line.move_id.product_uom_qty, 4)
         self.assertEqual(move_line.quantity, 4)
-        self.assertEqual(move_line.qty_done, 4)
+        self.assertEqual(move_line.qty_picked, 4)
 
     def test_set_destination_package_partial_qty_with_move_orig_ids(self):
         """Scanned destination location with partial qty, but related moves
@@ -943,9 +943,9 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         package1 = self.env["stock.quant.package"].create({})
         package2 = self.env["stock.quant.package"].create({})
         line1 = picking_a.move_line_ids
-        line2 = line1.copy({"quantity": 4, "qty_done": 4})
+        line2 = line1.copy({"quantity": 4, "qty_picked": 4})
         line1.with_context(bypass_reservation_update=True).quantity = 6
-        line1.qty_done = 6
+        line1.qty_picked = 6
         line1.result_package_id = package1
         line2.result_package_id = package2
         picking_a._action_done()
@@ -959,7 +959,7 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         move = move_line.move_id
 
         self.assertEqual(move_line.quantity, 6.0)
-        self.assertEqual(move_line.qty_done, 6.0)
+        self.assertEqual(move_line.qty_picked, 6.0)
         self._simulate_selected_move_line(move_line)
         # Scan partial qty (6/10)
         self.service.dispatch(
@@ -973,8 +973,8 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         )
         # Check move line data
         self.assertEqual(move_line.move_id.product_uom_qty, 6)
-        self.assertEqual(move_line.quantity, 0)
-        self.assertEqual(move_line.qty_done, 6)
+        self.assertEqual(move_line.quantity, 6)
+        self.assertEqual(move_line.qty_picked, 6)
         self.assertEqual(move_line.state, "done")
         # the move has been split
         self.assertNotEqual(move_line.move_id, move)
@@ -984,7 +984,7 @@ class LocationContentTransferSetDestinationChainSpecialCase(
         move_line = move.move_line_ids
         self.assertEqual(move_line.move_id.product_uom_qty, 4)
         self.assertEqual(move_line.quantity, 4)
-        self.assertEqual(move_line.qty_done, 4)
+        self.assertEqual(move_line.qty_picked, 4)
 
 
 class LocationContentTransferSetDestinationNextOperationSpecialCase(
@@ -1053,7 +1053,7 @@ class LocationContentTransferSetDestinationNextOperationSpecialCase(
         # check that the next operation has the appropriate attributes
         move_line = backorder.move_line_ids
         self.assertEqual(move_line.quantity, 4)
-        self.assertEqual(move_line.qty_done, 4)
+        self.assertEqual(move_line.qty_picked, 4)
         self.assertEqual(move_line.picking_id.user_id, self.env.user)
         # if we process the quantity of the backorder, the next operation should
         # be the remaining one of the initial picking

--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -631,11 +631,9 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
         the assigned user will be removed.
 
         """
-        self.env.user = self.shopfloor_manager
-        self.assertTrue(self.env.user != self.picking1.create_uid)
         package_level = self.picking1.move_line_ids.package_level_id
         move_lines_before = self.picking1.move_line_ids
-        move_lines_before.shopfloor_user_id = self.env.user
+        move_lines_before.shopfloor_user_id = self.env.ref("base.user_admin")
         response = self.service.dispatch(
             "stock_out_package",
             params={
@@ -852,12 +850,10 @@ class LocationContentTransferSingleSpecialCase(LocationContentTransferCommonCase
         compare to the previous test.
 
         """
-        self.env.user = self.shopfloor_manager
-        self.assertTrue(self.env.user != self.picking.create_uid)
         move_line = self.move_product_b.move_line_ids.filtered(
             lambda ml: ml.quantity == 4  # 4/10 to stock out
         )
-        move_line.shopfloor_user_id = self.env.user
+        move_line.shopfloor_user_id = self.env.ref("base.user_admin")
         self.service.dispatch(
             "stock_out_line",
             params={"location_id": self.content_loc.id, "move_line_id": move_line.id},

--- a/shopfloor/tests/test_location_content_transfer_start.py
+++ b/shopfloor/tests/test_location_content_transfer_start.py
@@ -114,9 +114,9 @@ class TestLocationContentTransferStart(LocationContentTransferCommonCase):
         self.assertRecordValues(
             processed_move_lines,
             [
-                {"qty_done": 10.0},
-                {"qty_done": 10.0},
-                {"qty_done": 10.0},
+                {"qty_picked": 10.0},
+                {"qty_picked": 10.0},
+                {"qty_picked": 10.0},
             ],
         )
         self.assertRecordValues(
@@ -142,9 +142,9 @@ class TestLocationContentTransferStart(LocationContentTransferCommonCase):
         self.assertRecordValues(
             processed_move_lines,
             [
-                {"qty_done": 10.0},
-                {"qty_done": 10.0},
-                {"qty_done": 10.0},
+                {"qty_picked": 10.0},
+                {"qty_picked": 10.0},
+                {"qty_picked": 10.0},
             ],
         )
         self.assertRecordValues(
@@ -239,7 +239,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
         self.assertRecordValues(new_picking, [{"user_id": self.env.uid}])
         self.assertRecordValues(
             new_picking.move_line_ids,
-            [{"qty_done": 10.0}, {"qty_done": 10.0}],
+            [{"qty_picked": 10.0}, {"qty_picked": 10.0}],
         )
         self.assertRecordValues(new_picking.package_level_ids, [{"is_done": True}])
 
@@ -249,12 +249,12 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
             picking.move_line_ids,
             [
                 {
-                    "qty_done": 0.0,
+                    "qty_picked": 0.0,
                     "location_id": self.shelf1.id,
                     "package_id": other_pack_a.id,
                 },
                 {
-                    "qty_done": 0.0,
+                    "qty_picked": 0.0,
                     "location_id": self.shelf1.id,
                     "package_id": other_pack_b.id,
                 },
@@ -285,7 +285,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
             picking.move_ids, in_package=True, location=self.content_loc
         )
         picking.action_assign()
-        picking.move_line_ids[0].qty_done = 10
+        picking.move_line_ids[0].qty_picked = 10
         response = self.service.dispatch(
             "scan_location", params={"barcode": self.content_loc.barcode}
         )
@@ -315,7 +315,7 @@ class LocationContentTransferStartSpecialCase(LocationContentTransferCommonCase)
         )
         picking.action_assign()
         # a user picked qty
-        picking.move_line_ids[0].qty_done = 10
+        picking.move_line_ids[0].qty_picked = 10
         response = self.service.dispatch(
             "scan_location", params={"barcode": self.content_loc.barcode}
         )


### PR DESCRIPTION
Depends on:
- ~https://github.com/OCA/stock-logistics-workflow/pull/2058~
- https://github.com/OCA/stock-logistics-workflow/pull/2076

Required a fix on `stock_storage_type` to make CI :green_circle: :
- https://github.com/OCA/stock-logistics-putaway/pull/12

Ref 5991