### PR TITLE
[18.0][FIX] shopfloor: fixing `zone_picking` scenario

### DIFF
--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -149,7 +149,9 @@ class SearchAction(Component):
         if not barcode:
             return model.browse()
         domain = [
+            "|",
             ("company_id", "=", self.env.company.id),
+            ("company_id", "=", False),
             ("name", "=", barcode),
         ]
         if products:

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -63,7 +63,7 @@ class ZonePicking(Component):
        * they scan a location, in which case the move line's destination is
          updated with it and the move is done
        * they scan a package, which becomes the destination package of the move
-         line, the move line is not set to done, its ``qty_done`` is updated
+         line, the move line is not set to done, its ``qty_picked`` is updated
          and a field ``shopfloor_user_id`` is set to the user; consider the
          move line is set in a buffer
 
@@ -451,7 +451,6 @@ class ZonePicking(Component):
     def _find_buffer_move_lines_domain(self, dest_package=None):
         domain = [
             ("picking_id.picking_type_id", "in", self.picking_types.ids),
-            ("qty_picked", ">", 0),
             ("picked", "=", True),
             ("state", "not in", ("cancel", "done")),
             ("result_package_id", "!=", False),
@@ -1152,7 +1151,7 @@ class ZonePicking(Component):
           moved is 0 in the source location after the move (beware: at this
           point the product we put in the buffer is still considered to be in
           the source location, so we have to compute the source location's
-          quantity - qty_done).
+          quantity - picked qty).
         * set_line_destination: the scanned location is invalid, user has to
           scan another one
         * set_line_destination+confirmation_required: the scanned location is not
@@ -1352,7 +1351,7 @@ class ZonePicking(Component):
             ("package_id", "=", package.id),
             ("lot_id", "=", lot.id),
             ("state", "not in", ("cancel", "done")),
-            ("qty_picked", "=", 0),
+            ("picked", "=", False),
         ]
         return domain
 
@@ -1363,11 +1362,11 @@ class ZonePicking(Component):
         because there is physically not enough goods. The move line is deleted
         (unreserve), and an inventory is created to reduce the quantity in the
         source location to prevent future errors until a correction. Beware:
-        the quantity already reserved and having a qty_done set on other lines
+        the quantity already reserved and having a picked qty on other lines
         in the same location should remain reserved so the inventory's quantity
-        must be set to the total of qty_done of other lines.
+        must be set to the total of picked qty of other lines.
 
-        The other lines not yet picked (no qty_done) in the same location for
+        The other lines not yet picked in the same location for
         the same product, lot, package are unreserved as well (moves lines
         deleted, which unreserve their quantity on the move).
 
@@ -1483,7 +1482,7 @@ class ZonePicking(Component):
 
         * in the current zone location and picking type
         * not done or canceled
-        * with a qty_done > 0
+        * picked
         * have a destination package
         * with ``shopfloor_user_id`` equal to the current user
 

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -76,8 +76,7 @@ from . import test_zone_picking_set_line_destination_no_prefill_qty
 from . import test_zone_picking_set_line_destination_pick_pack
 from . import test_zone_picking_zero_check
 from . import test_zone_picking_stock_issue
-
-# from . import test_zone_picking_change_pack_lot
+from . import test_zone_picking_change_pack_lot
 from . import test_zone_picking_unload_buffer_lines
 from . import test_zone_picking_unload_single
 from . import test_zone_picking_unload_all

--- a/shopfloor/tests/test_zone_picking_select_line.py
+++ b/shopfloor/tests/test_zone_picking_select_line.py
@@ -160,7 +160,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
             qty_done=10.0,
         )
         # first line done
-        move_line._pick_qty(move_line.quantity)
+        move_line.picked = True
         # get the next one
         response = self.service.dispatch(
             "scan_source",
@@ -751,7 +751,7 @@ class ZonePickingSelectLineCase(ZonePickingCommonCase):
         )
         self.assertTrue(move_line_will_empty_location)
         # But if we check the location without giving the move line as parameter,
-        # knowing that this move line hasn't its 'qty_done' field filled,
+        # knowing that this move line hasn't its 'qty_picked' field filled,
         # the location won't be considered empty with such pending move line
         move_line_will_empty_location = location_src.planned_qty_in_location_is_empty()
         self.assertFalse(move_line_will_empty_location)

--- a/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
@@ -68,7 +68,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
         move_line = self.picking1.move_line_ids
         move_line.location_dest_id = self.shelf1
         quantity_reserved = move_line.quantity
-        previous_qty_done = move_line.qty_picked
+        previous_qty_picked = move_line.qty_picked
         # Confirm the destination with the right destination
         response = self.service.dispatch(
             "set_destination",
@@ -78,7 +78,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
                 "quantity": quantity_reserved,
             },
         )
-        self.assertEqual(move_line.qty_picked, previous_qty_done)
+        self.assertEqual(move_line.qty_picked, previous_qty_picked)
         self.assert_response_set_line_destination(
             response,
             zone_location,


### PR DESCRIPTION
I think you discarded my fixup @simahawk when rebasing/merging https://github.com/OCA/stock-logistics-shopfloor/pull/16 :)