### PR TITLE
[ADD][18.0] shopfloor_reception_measuring_device

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
@@ -219,7 +219,7 @@ export var PackagingQtyPicker = Vue.component("packaging-qty-picker", {
     },
     computed: {
         qty_color_class: function () {
-            if (this.qty == this.qtyTodo) {
+            if (this.qty === this.qtyTodo) {
                 if (this.readonly) return "";
                 return "qty-color-green";
             }

--- a/shopfloor_mobile/static/wms/src/demo/demo.components.esm.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.components.esm.js
@@ -4,9 +4,9 @@
  * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
  */
 
+import {demotools} from "/shopfloor_mobile_base/static/src/demo/demo.core.esm.js";
 import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/src/scenario/mixins.esm.js";
 import {process_registry} from "/shopfloor_mobile_base/static/src/services/process_registry.esm.js";
-import {demotools} from "/shopfloor_mobile_base/static/src/demo/demo.core.esm.js";
 
 const DemoComponents = {
     mixins: [ScenarioBaseMixin],

--- a/shopfloor_reception_measuring_device/__init__.py
+++ b/shopfloor_reception_measuring_device/__init__.py
@@ -1,0 +1,2 @@
+from . import actions
+from . import services

--- a/shopfloor_reception_measuring_device/__manifest__.py
+++ b/shopfloor_reception_measuring_device/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+{
+    "name": "Shopfloor Reception Measuring Device",
+    "summary": "Allows to use measuring devices to measure packagings on the reception",
+    "version": "18.0.1.0.0",
+    "development_status": "Alpha",
+    "category": "Inventory",
+    "website": "https://github.com/OCA/stock-logistics-shopfloor",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["mmequignon", "simahawk"],
+    "license": "AGPL-3",
+    "installable": True,
+    "depends": [
+        "shopfloor_reception_packaging_dimension",
+        "stock_measuring_device",
+    ],
+}

--- a/shopfloor_reception_measuring_device/actions/__init__.py
+++ b/shopfloor_reception_measuring_device/actions/__init__.py
@@ -1,0 +1,1 @@
+from . import messages

--- a/shopfloor_reception_measuring_device/actions/messages.py
+++ b/shopfloor_reception_measuring_device/actions/messages.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.component.core import Component
+
+
+class MessageAction(Component):
+    _inherit = "shopfloor.message.action"
+
+    def no_measuring_device_found(self):
+        return {
+            "message_type": "error",
+            "body": self.env._("No measuring device found"),
+        }
+
+    def measuring_device_already_in_use(self, device):
+        return {
+            "message_type": "error",
+            "body": self.env._(
+                "Measuring device %(name)s already in use", name=device.name
+            ),
+        }
+
+    def measuring_device_selected(self, device, packaging):
+        return {
+            "message_type": "success",
+            "body": self.env._(
+                (
+                    "The device %(name)s has been reserved, "
+                    "you can now measure packaging %(packaging)s"
+                ),
+                name=device.name,
+                packaging=packaging.name,
+            ),
+        }
+
+    def no_measuring_device_to_release(self, packaging):
+        return {
+            "message_type": "warning",
+            "body": self.env._(
+                "No measuring device to release from packaging %(packaging)s",
+                packaging=packaging.name,
+            ),
+        }
+
+    def measuring_device_released(self, packaging, device):
+        return {
+            "message_type": "success",
+            "body": self.env._(
+                "The device has %(device_name)s has been released "
+                "from packaging %(packaging_name)s",
+                device_name=device.name,
+                packaging_name=packaging.name,
+            ),
+        }

--- a/shopfloor_reception_measuring_device/pyproject.toml
+++ b/shopfloor_reception_measuring_device/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"

--- a/shopfloor_reception_measuring_device/readme/CONTRIBUTORS.md
+++ b/shopfloor_reception_measuring_device/readme/CONTRIBUTORS.md
@@ -1,0 +1,2 @@
+- Matthieu Mequignon \<<matthieu.mequignon@camptocamp.com>\>
+- Simone Orsi \<<simone.orsi@camptocamp.com>\>

--- a/shopfloor_reception_measuring_device/readme/DESCRIPTION.md
+++ b/shopfloor_reception_measuring_device/readme/DESCRIPTION.md
@@ -1,0 +1,3 @@
+Glue module between shopfloor_reception_packaging_dimension and stock_measuring_device,
+allowing users to use a measuring device (zippcube, cubiscan) during the set_packaging_dimension
+step.

--- a/shopfloor_reception_measuring_device/services/__init__.py
+++ b/shopfloor_reception_measuring_device/services/__init__.py
@@ -1,0 +1,1 @@
+from . import reception

--- a/shopfloor_reception_measuring_device/services/reception.py
+++ b/shopfloor_reception_measuring_device/services/reception.py
@@ -1,0 +1,109 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.base_rest.components.service import to_int
+from odoo.addons.component.core import Component
+
+
+class Reception(Component):
+    _inherit = "shopfloor.reception"
+
+    def _get_measuring_device_domain(self):
+        return []
+
+    def set_packaging_dimension__measuring_device_assign(
+        self, picking_id, selected_line_id, packaging_id
+    ):
+        picking = self.env["stock.picking"].sudo().browse(picking_id)
+        selected_line = self.env["stock.move.line"].sudo().browse(selected_line_id)
+        packaging = self.env["product.packaging"].sudo().browse(packaging_id)
+        device_domain = self._get_measuring_device_domain()
+        device = self.env["measuring.device"].search(device_domain)
+        if not packaging:
+            msg = self.msg_store.record_not_found()
+        elif not device:
+            msg = self.msg_store.no_measuring_device_found()
+        elif device._is_being_used():
+            msg = self.msg_store.measuring_device_already_in_use(device)
+        else:
+            packaging._measuring_device_assign(device)
+            msg = self.msg_store.measuring_device_selected(device, packaging)
+        return self._response_for_set_packaging_dimension(
+            picking, selected_line, packaging, message=msg
+        )
+
+    def set_packaging_dimension__measuring_device_release(
+        self, picking_id, selected_line_id, packaging_id
+    ):
+        picking = self.env["stock.picking"].sudo().browse(picking_id)
+        selected_line = self.env["stock.move.line"].sudo().browse(selected_line_id)
+        packaging = self.env["product.packaging"].sudo().browse(packaging_id)
+        device = packaging.measuring_device_id
+        if not packaging:
+            msg = self.msg_store.record_not_found()
+        elif not device:
+            msg = self.msg_store.no_measuring_device_to_release(packaging)
+        else:
+            packaging._measuring_device_release()
+            msg = self.msg_store.measuring_device_released(packaging, device)
+        return self._response_for_set_packaging_dimension(
+            picking, selected_line, packaging, message=msg
+        )
+
+    def _set_packaging_dimension_data_for_packaging(self, packaging):
+        # Add flag `is_being_measured` to indicate
+        # if the packaging is being measured on the app
+        return dict(
+            super()._set_packaging_dimension_data_for_packaging(packaging),
+            is_being_measured=bool(packaging.measuring_device_id),
+        )
+
+
+class ShopfloorReceptionValidator(Component):
+    _inherit = "shopfloor.reception.validator"
+
+    def set_packaging_dimension__measuring_device_assign(self):
+        return {
+            "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "selected_line_id": {
+                "coerce": to_int,
+                "required": True,
+                "type": "integer",
+            },
+            "packaging_id": {"coerce": to_int, "required": True, "type": "integer"},
+        }
+
+    def set_packaging_dimension__measuring_device_release(self):
+        return {
+            "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
+            "selected_line_id": {
+                "coerce": to_int,
+                "required": True,
+                "type": "integer",
+            },
+            "packaging_id": {"coerce": to_int, "required": True, "type": "integer"},
+        }
+
+
+class ShopfloorReceptionValidatorResponse(Component):
+    _inherit = "shopfloor.reception.validator.response"
+
+    def _set_packaging_dimension__measuring_device_next_states(self):
+        # If the measuring device assign/cancel button is pressed,
+        # get back on the same screen.
+        return {"set_packaging_dimension"}
+
+    def set_packaging_dimension__measuring_device_assign(self):
+        return self._response_schema(
+            next_states=self._set_packaging_dimension__measuring_device_next_states()
+        )
+
+    def set_packaging_dimension__measuring_device_release(self):
+        return self._response_schema(
+            next_states=self._set_packaging_dimension__measuring_device_next_states()
+        )
+
+    def _schema_packaging(self):
+        schema = super()._schema_packaging()
+        schema["schema"]["is_being_measured"] = {"type": "boolean", "default": False}
+        return schema

--- a/shopfloor_reception_measuring_device/static/description/index.html
+++ b/shopfloor_reception_measuring_device/static/description/index.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
+<title>README.rst</title>
+<style type="text/css">
+
+/*
+:Author: David Goodger (goodger@python.org)
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Copyright: This stylesheet has been placed in the public domain.
+
+Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
+
+See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
+customize this style sheet.
+*/
+
+/* used to remove borders from tables and images */
+.borderless, table.borderless td, table.borderless th {
+  border: 0 }
+
+table.borderless td, table.borderless th {
+  /* Override padding for "table.docutils td" with "! important".
+     The right padding separates the table cells. */
+  padding: 0 0.5em 0 0 ! important }
+
+.first {
+  /* Override more specific margin styles with "! important". */
+  margin-top: 0 ! important }
+
+.last, .with-subtitle {
+  margin-bottom: 0 ! important }
+
+.hidden {
+  display: none }
+
+.subscript {
+  vertical-align: sub;
+  font-size: smaller }
+
+.superscript {
+  vertical-align: super;
+  font-size: smaller }
+
+a.toc-backref {
+  text-decoration: none ;
+  color: black }
+
+blockquote.epigraph {
+  margin: 2em 5em ; }
+
+dl.docutils dd {
+  margin-bottom: 0.5em }
+
+object[type="image/svg+xml"], object[type="application/x-shockwave-flash"] {
+  overflow: hidden;
+}
+
+/* Uncomment (and remove this text!) to get bold-faced definition list terms
+dl.docutils dt {
+  font-weight: bold }
+*/
+
+div.abstract {
+  margin: 2em 5em }
+
+div.abstract p.topic-title {
+  font-weight: bold ;
+  text-align: center }
+
+div.admonition, div.attention, div.caution, div.danger, div.error,
+div.hint, div.important, div.note, div.tip, div.warning {
+  margin: 2em ;
+  border: medium outset ;
+  padding: 1em }
+
+div.admonition p.admonition-title, div.hint p.admonition-title,
+div.important p.admonition-title, div.note p.admonition-title,
+div.tip p.admonition-title {
+  font-weight: bold ;
+  font-family: sans-serif }
+
+div.attention p.admonition-title, div.caution p.admonition-title,
+div.danger p.admonition-title, div.error p.admonition-title,
+div.warning p.admonition-title, .code .error {
+  color: red ;
+  font-weight: bold ;
+  font-family: sans-serif }
+
+/* Uncomment (and remove this text!) to get reduced vertical space in
+   compound paragraphs.
+div.compound .compound-first, div.compound .compound-middle {
+  margin-bottom: 0.5em }
+
+div.compound .compound-last, div.compound .compound-middle {
+  margin-top: 0.5em }
+*/
+
+div.dedication {
+  margin: 2em 5em ;
+  text-align: center ;
+  font-style: italic }
+
+div.dedication p.topic-title {
+  font-weight: bold ;
+  font-style: normal }
+
+div.figure {
+  margin-left: 2em ;
+  margin-right: 2em }
+
+div.footer, div.header {
+  clear: both;
+  font-size: smaller }
+
+div.line-block {
+  display: block ;
+  margin-top: 1em ;
+  margin-bottom: 1em }
+
+div.line-block div.line-block {
+  margin-top: 0 ;
+  margin-bottom: 0 ;
+  margin-left: 1.5em }
+
+div.sidebar {
+  margin: 0 0 0.5em 1em ;
+  border: medium outset ;
+  padding: 1em ;
+  background-color: #ffffee ;
+  width: 40% ;
+  float: right ;
+  clear: right }
+
+div.sidebar p.rubric {
+  font-family: sans-serif ;
+  font-size: medium }
+
+div.system-messages {
+  margin: 5em }
+
+div.system-messages h1 {
+  color: red }
+
+div.system-message {
+  border: medium outset ;
+  padding: 1em }
+
+div.system-message p.system-message-title {
+  color: red ;
+  font-weight: bold }
+
+div.topic {
+  margin: 2em }
+
+h1.section-subtitle, h2.section-subtitle, h3.section-subtitle,
+h4.section-subtitle, h5.section-subtitle, h6.section-subtitle {
+  margin-top: 0.4em }
+
+h1.title {
+  text-align: center }
+
+h2.subtitle {
+  text-align: center }
+
+hr.docutils {
+  width: 75% }
+
+img.align-left, .figure.align-left, object.align-left, table.align-left {
+  clear: left ;
+  float: left ;
+  margin-right: 1em }
+
+img.align-right, .figure.align-right, object.align-right, table.align-right {
+  clear: right ;
+  float: right ;
+  margin-left: 1em }
+
+img.align-center, .figure.align-center, object.align-center {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+table.align-center {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.align-left {
+  text-align: left }
+
+.align-center {
+  clear: both ;
+  text-align: center }
+
+.align-right {
+  text-align: right }
+
+/* reset inner alignment in figures */
+div.align-right {
+  text-align: inherit }
+
+/* div.align-center * { */
+/*   text-align: left } */
+
+.align-top    {
+  vertical-align: top }
+
+.align-middle {
+  vertical-align: middle }
+
+.align-bottom {
+  vertical-align: bottom }
+
+ol.simple, ul.simple {
+  margin-bottom: 1em }
+
+ol.arabic {
+  list-style: decimal }
+
+ol.loweralpha {
+  list-style: lower-alpha }
+
+ol.upperalpha {
+  list-style: upper-alpha }
+
+ol.lowerroman {
+  list-style: lower-roman }
+
+ol.upperroman {
+  list-style: upper-roman }
+
+p.attribution {
+  text-align: right ;
+  margin-left: 50% }
+
+p.caption {
+  font-style: italic }
+
+p.credits {
+  font-style: italic ;
+  font-size: smaller }
+
+p.label {
+  white-space: nowrap }
+
+p.rubric {
+  font-weight: bold ;
+  font-size: larger ;
+  color: maroon ;
+  text-align: center }
+
+p.sidebar-title {
+  font-family: sans-serif ;
+  font-weight: bold ;
+  font-size: larger }
+
+p.sidebar-subtitle {
+  font-family: sans-serif ;
+  font-weight: bold }
+
+p.topic-title {
+  font-weight: bold }
+
+pre.address {
+  margin-bottom: 0 ;
+  margin-top: 0 ;
+  font: inherit }
+
+pre.literal-block, pre.doctest-block, pre.math, pre.code {
+  margin-left: 2em ;
+  margin-right: 2em }
+
+pre.code .ln { color: gray; } /* line numbers */
+pre.code, code { background-color: #eeeeee }
+pre.code .comment, code .comment { color: #5C6576 }
+pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
+pre.code .literal.string, code .literal.string { color: #0C5404 }
+pre.code .name.builtin, code .name.builtin { color: #352B84 }
+pre.code .deleted, code .deleted { background-color: #DEB0A1}
+pre.code .inserted, code .inserted { background-color: #A3D289}
+
+span.classifier {
+  font-family: sans-serif ;
+  font-style: oblique }
+
+span.classifier-delimiter {
+  font-family: sans-serif ;
+  font-weight: bold }
+
+span.interpreted {
+  font-family: sans-serif }
+
+span.option {
+  white-space: nowrap }
+
+span.pre {
+  white-space: pre }
+
+span.problematic, pre.problematic {
+  color: red }
+
+span.section-subtitle {
+  /* font-size relative to parent (h1..h6 element) */
+  font-size: 80% }
+
+table.citation {
+  border-left: solid 1px gray;
+  margin-left: 1px }
+
+table.docinfo {
+  margin: 2em 4em }
+
+table.docutils {
+  margin-top: 0.5em ;
+  margin-bottom: 0.5em }
+
+table.footnote {
+  border-left: solid 1px black;
+  margin-left: 1px }
+
+table.docutils td, table.docutils th,
+table.docinfo td, table.docinfo th {
+  padding-left: 0.5em ;
+  padding-right: 0.5em ;
+  vertical-align: top }
+
+table.docutils th.field-name, table.docinfo th.docinfo-name {
+  font-weight: bold ;
+  text-align: left ;
+  white-space: nowrap ;
+  padding-left: 0 }
+
+/* "booktabs" style (no vertical lines) */
+table.docutils.booktabs {
+  border: 0px;
+  border-top: 2px solid;
+  border-bottom: 2px solid;
+  border-collapse: collapse;
+}
+table.docutils.booktabs * {
+  border: 0px;
+}
+table.docutils.booktabs th {
+  border-bottom: thin solid;
+  text-align: left;
+}
+
+h1 tt.docutils, h2 tt.docutils, h3 tt.docutils,
+h4 tt.docutils, h5 tt.docutils, h6 tt.docutils {
+  font-size: 100% }
+
+ul.auto-toc {
+  list-style-type: none }
+
+</style>
+</head>
+<body>
+<div class="document">
+
+
+
+</div>
+</body>
+</html>

--- a/shopfloor_reception_measuring_device/tests/__init__.py
+++ b/shopfloor_reception_measuring_device/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_reception_measuring_device

--- a/shopfloor_reception_measuring_device/tests/device_component.py
+++ b/shopfloor_reception_measuring_device/tests/device_component.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo.addons.component.core import Component
+
+
+class MeasuringComponent(Component):
+    _name = "device.component.testdevice"
+    _inherit = "measuring.device.base"
+    _usage = "testdevice"

--- a/shopfloor_reception_measuring_device/tests/device_model.py
+++ b/shopfloor_reception_measuring_device/tests/device_model.py
@@ -1,0 +1,10 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class MeasuringModel(models.Model):
+    _inherit = "measuring.device"
+
+    device_type = fields.Selection(selection_add=[("testdevice", "TestDevice")])

--- a/shopfloor_reception_measuring_device/tests/test_reception_measuring_device.py
+++ b/shopfloor_reception_measuring_device/tests/test_reception_measuring_device.py
@@ -1,0 +1,205 @@
+# Copyright 2025 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo_test_helper import FakeModelLoader
+
+from odoo.tools import mute_logger
+
+from odoo.addons.shopfloor_reception.tests.common import CommonCase
+
+
+class TestSetPackDimension(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.menu.sudo().set_packaging_dimension = True
+        cls.wh = cls.env.ref("stock.warehouse0")
+        cls.setUpClassPackaging()
+        cls.setUpComponentRegistry()
+        cls.setUpClassMeasuringDevice()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        return super().tearDownClass()
+
+    @classmethod
+    def setup_picking(cls):
+        return cls._create_picking(lines=[(cls.product_c, 10)])
+
+    @classmethod
+    def setUpComponentRegistry(cls):
+        from .device_component import MeasuringComponent
+
+        MeasuringComponent._build_component(cls._components_registry)
+
+    @classmethod
+    def setUpClassPackaging(cls):
+        cls.packaging1 = cls.product_c.packaging_ids
+        cls.packaging2 = (
+            cls.env["product.packaging"]
+            .sudo()
+            .create(
+                {
+                    "name": "Big Box",
+                    "product_id": cls.product_c.id,
+                    "barcode": "ProductCBigBox",
+                    "qty": 6,
+                }
+            )
+        )
+
+    @classmethod
+    def setUpClassMeasuringDevice(cls):
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .device_model import MeasuringModel
+
+        cls.loader.update_registry((MeasuringModel,))
+        cls.device_model = cls.env["measuring.device"].sudo()
+        cls.device = cls.device_model.create(
+            {
+                "name": "Test Device",
+                "device_type": "testdevice",
+                "state": "ready",
+                "warehouse_id": cls.wh.id,
+            }
+        )
+
+    def _assert_response_set_dimension(
+        self, response, picking, line, packaging, message=None
+    ):
+        data = {
+            "picking": self.data.picking(picking),
+            "selected_move_line": self.data.move_line(line),
+            "packaging": dict(
+                self.data_detail.packaging_detail(packaging),
+                is_being_measured=bool(packaging.measuring_device_id),
+            ),
+        }
+        self.assert_response(
+            response,
+            next_state="set_packaging_dimension",
+            data=data,
+            message=message,
+        )
+
+    def test_select_device__no_device(self):
+        picking = self.setup_picking()
+        line = picking.move_line_ids[0]
+        # Unlink device so none is found
+        self.device.unlink()
+        response = self.service.dispatch(
+            "set_packaging_dimension__measuring_device_assign",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line.id,
+                "packaging_id": self.packaging1.id,
+            },
+        )
+        self._assert_response_set_dimension(
+            response,
+            picking,
+            line,
+            self.packaging1,
+            message=self.msg_store.no_measuring_device_found(),
+        )
+
+    def test_select_device__device_already_assigned(self):
+        picking = self.setup_picking()
+        line = picking.move_line_ids[0]
+        # assign measuring device to packaging2, so it cannot be selected again
+        self.packaging2._measuring_device_assign(self.device)
+        response = self.service.dispatch(
+            "set_packaging_dimension__measuring_device_assign",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line.id,
+                "packaging_id": self.packaging1.id,
+            },
+        )
+        self._assert_response_set_dimension(
+            response,
+            picking,
+            line,
+            self.packaging1,
+            message=self.msg_store.measuring_device_already_in_use(self.device),
+        )
+
+    @mute_logger("odoo.addons.stock_measuring_device.models.measuring_device")
+    def test_select_device__ok(self):
+        picking = self.setup_picking()
+        line = picking.move_line_ids[0]
+        response = self.service.dispatch(
+            "set_packaging_dimension__measuring_device_assign",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line.id,
+                "packaging_id": self.packaging1.id,
+            },
+        )
+        self._assert_response_set_dimension(
+            response,
+            picking,
+            line,
+            self.packaging1,
+            message=self.msg_store.measuring_device_selected(
+                self.device, self.packaging1
+            ),
+        )
+        self.assertEqual(self.packaging1.measuring_device_id, self.device)
+        measurements = {
+            "weight": 42,
+            "height": 43,
+            "packaging_length": 44,
+            "width": 45,
+        }
+        measured_packaging = self.device._update_packaging_measures(measurements)
+        self.assertEqual(measured_packaging, self.packaging1)
+        self.assertEqual(measured_packaging.weight, 42)
+        self.assertEqual(measured_packaging.height, 43)
+        self.assertEqual(measured_packaging.packaging_length, 44)
+        self.assertEqual(measured_packaging.width, 45)
+
+    def test_release_device__no_device_assigned(self):
+        picking = self.setup_picking()
+        line = picking.move_line_ids[0]
+        response = self.service.dispatch(
+            "set_packaging_dimension__measuring_device_release",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line.id,
+                "packaging_id": self.packaging1.id,
+            },
+        )
+        self._assert_response_set_dimension(
+            response,
+            picking,
+            line,
+            self.packaging1,
+            message=self.msg_store.no_measuring_device_to_release(self.packaging1),
+        )
+
+    def test_release_device__ok(self):
+        picking = self.setup_picking()
+        line = picking.move_line_ids[0]
+        # Assign device to the packaging so it can be released
+        self.packaging1._measuring_device_assign(self.device)
+        response = self.service.dispatch(
+            "set_packaging_dimension__measuring_device_release",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": line.id,
+                "packaging_id": self.packaging1.id,
+            },
+        )
+        self._assert_response_set_dimension(
+            response,
+            picking,
+            line,
+            self.packaging1,
+            message=self.msg_store.measuring_device_released(
+                self.packaging1, self.device
+            ),
+        )
+        self.assertFalse(self.packaging1.measuring_device_id)

--- a/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
@@ -477,7 +477,7 @@ const Reception = {
                 on_title_action: this.package_type_select,
             };
 
-            if (withAction == true) {
+            if (withAction === true) {
                 return Object.assign(options, optionsAction);
             }
             return options;


### PR DESCRIPTION
Depends on
- #21 
- https://github.com/OCA/stock-logistics-interfaces/pull/5


This module will need a mobile companion module which will:
 - Display a `use measure device` on the get measurement screen if no device is set on the packaging
 - Display the `cancel measurement` on  the get measurement screen if a device is set on the packaging