### PR TITLE
[18.0] shopfloor_reception: Fix tests by assigning qty_picked to reserved

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1319,6 +1319,7 @@ class Reception(Component):
         new_move = move.create(split_move_vals)
         new_move.move_line_ids = selected_line
         new_move._action_confirm(merge=False)
+        selected_line.quantity = selected_line.qty_picked
         new_move._recompute_state()
         new_move._action_assign()
         # Set back the quantity to do on one of the lines

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -719,11 +719,10 @@ class TestSetQuantity(CommonCase):
         lines_after = self.env["stock.move.line"].search(
             [("id", "not in", lines_before.ids)]
         )
-        # FIXME: Check _auto_post_line with MMQ?
         # After move_line is posted, its state is done, and its qty_picked is 1.0
         self.assertEqual(move_line_user_1.state, "done")
         # The remaining one is still to be done
-        self.assertEqual(move_line_user_2.state, "partially_available")
+        self.assertEqual(move_line_user_2.state, "assigned")
         # As well as the new one
         self.assertEqual(len(lines_after), 1)
         # The quantity to do is set on 1 of the lines


### PR DESCRIPTION
Since stock.move.quantity field is not anymore computed according to the qty_picked, it highlighted an issue in the existing test where the reserved qty is not reset after being forced to 0.