### PR TITLE
[18.0] shopfloor_mobile: fix packaging-qty-picker qty per pkg

### DIFF
--- a/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
+++ b/shopfloor_mobile/static/wms/src/components/packaging-qty-picker.esm.js
@@ -89,11 +89,13 @@ export var PackagingQtyPickerMixin = {
         _product_qty_by_packaging: function (pkg_by_qty, qty) {
             const self = this;
             const res = {};
+            /* eslint-disable no-param-reassign */
             // Const min_unit = _.last(pkg_by_qty);
             pkg_by_qty.forEach(function (pkg) {
-                const [_qty_per_pkg, _qty] = self._qty_by_pkg(pkg.qty, qty);
-                res[pkg.id] = _qty_per_pkg;
-                if (!_qty) return;
+                let qty_per_pkg = 0;
+                [qty_per_pkg, qty] = self._qty_by_pkg(pkg.qty, qty);
+                res[pkg.id] = qty_per_pkg;
+                if (!qty) return;
             });
             return res;
         },

--- a/shopfloor_mobile/static/wms/src/demo/demo.components.esm.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.components.esm.js
@@ -1,0 +1,118 @@
+/**
+ * Copyright 2025 Camptocamp SA (http://www.camptocamp.com)
+ * @author Simone Orsi <simahawk@gmail.com>
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+ */
+
+import {ScenarioBaseMixin} from "/shopfloor_mobile_base/static/src/scenario/mixins.esm.js";
+import {process_registry} from "/shopfloor_mobile_base/static/src/services/process_registry.esm.js";
+import {demotools} from "/shopfloor_mobile_base/static/src/demo/demo.core.esm.js";
+
+const DemoComponents = {
+    mixins: [ScenarioBaseMixin],
+    template: `
+        <Screen :screen_info="screen_info">
+            <template v-slot:header>
+                <state-display-info :info="state.display_info" v-if="state.display_info"/>
+            </template>
+            <div v-if="state_is('packaging_qty_picker_display')"">
+                <separator-title>Only qty to pick</separator-title>
+                <v-card
+                    v-for="line in packaging_qty_picker_display_get_lines()">
+                    <packaging-qty-picker-display
+                        :key="make_state_component_key(['qty-picker-widget', line.id])"
+                        v-bind="utils.wms.move_line_qty_picker_props(line, {'qtyInit': line.quantity})"
+                    />
+                </v-card>
+                <separator-title>All corresponding packaging</separator-title>
+                <v-card
+                    v-for="line in packaging_qty_picker_display_get_lines()">
+                    <packaging-qty-picker-display
+                        :nonZeroOnly="false"
+                        :key="make_state_component_key(['qty-picker-widget', line.id])"
+                        v-bind="utils.wms.move_line_qty_picker_props(line, {'qtyInit': line.quantity})"
+                    />
+                </v-card>
+            </div>
+            <div v-if="state_is('packaging_qty_picker_edit')">
+                <separator-title>Edit mode</separator-title>
+                <v-card
+                    v-for="line in packaging_qty_picker_display_get_lines()">
+                    <packaging-qty-picker
+                        :key="make_state_component_key(['qty-picker-widget', line.id])"
+                        v-bind="utils.wms.move_line_qty_picker_props(line, {'qtyInit': line.quantity})"
+                    />
+                </v-card>
+            </div>
+            <div class="button-list button-vertical-list full">
+                <v-row align="center" v-if="state_is('packaging_qty_picker_display')">
+                    <v-col class="text-center" cols="12">
+                        <btn-action @click="state_to('packaging_qty_picker_edit')">Edit mode</btn-action>
+                    </v-col>
+                </v-row>
+                <v-row align="center" v-if="state_is('packaging_qty_picker_edit')">
+                    <v-col class="text-center" cols="12">
+                        <btn-action @click="state_to('packaging_qty_picker_display')">Display mode</btn-action>
+                    </v-col>
+                </v-row>
+            </div>
+        </Screen>
+    `,
+    data: function () {
+        return {
+            usage: "demo_components",
+            initial_state_key: "packaging_qty_picker_display",
+            states: {
+                packaging_qty_picker_display: {
+                    display_info: {
+                        title: "Packaging Qty Picker Display",
+                    },
+                },
+                packaging_qty_picker_edit: {
+                    display_info: {
+                        title: "Packaging Qty Picker Edit",
+                    },
+                },
+            },
+        };
+    },
+    methods: {
+        packaging_qty_picker_display_get_lines: function () {
+            const lines = [];
+            const product1 = demotools.makeProduct({uom: demotools.uom_unit});
+            product1.packaging = [
+                demotools.makePackaging({qty: 5, code: "TU", name: "Pack of 5"}),
+                demotools.makePackaging({qty: 10, code: "BX", name: "Box of 10"}),
+                demotools.makePackaging({qty: 20, code: "BBX", name: "Big Box of 20"}),
+            ];
+            const line1 = demotools.makeMoveLine({
+                // This should be represented as: 1001 units (50 BBX, 1 TU, 1 unit)
+                quantity: 1006,
+                product: product1,
+            });
+            lines.push(line1);
+            return lines;
+        },
+    },
+};
+process_registry.add("demo_components", DemoComponents);
+
+const menuitem_id = demotools.addAppMenu(
+    {
+        name: "Demo components",
+        scenario: "demo_components",
+        sequence: 999,
+    },
+    "demo_cp_1"
+);
+const CASE = {
+    demo_components: {
+        next_state: "demo_components",
+        data: {
+            demo_components: {},
+        },
+    },
+};
+demotools.add_case("demo_components", menuitem_id, CASE);
+
+export default DemoComponents;

--- a/shopfloor_mobile/templates/assets.xml
+++ b/shopfloor_mobile/templates/assets.xml
@@ -175,6 +175,11 @@
                 t-attf-src="/shopfloor_mobile/static/wms/src/demo/demo.location_content_transfer.esm.js?v=#{mod_version}"
                 type="module"
             />
+            <script
+                id="script_demo_components"
+                t-attf-src="/shopfloor_mobile/static/wms/src/demo/demo.components.esm.js?v=#{mod_version}"
+                type="module"
+            />
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
A change derived from linting broke the computation of qty per_pkg
thus breaking the correct editing and display.

I've also added a demo scenario for single components

<img width="423" height="405" alt="image" src="https://github.com/user-attachments/assets/1c3f0aee-8615-4d43-af99-03214d17ef51" />

<img width="422" height="476" alt="image" src="https://github.com/user-attachments/assets/95120807-df85-43df-894c-2b2d35c96400" />


This demo improvement requires this change

- https://github.com/OCA/shopfloor-app/pull/14