### PR TITLE
[18.0][FIX] shopfloor: fix migration for package type

### DIFF
--- a/shopfloor/actions/__init__.py
+++ b/shopfloor/actions/__init__.py
@@ -12,4 +12,4 @@ from . import savepoint
 from . import move_line_search
 from . import stock
 from . import stock_unreserve
-from . import packaging
+from . import packing

--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -76,15 +76,15 @@ class DataAction(Component):
         ]
 
     @ensure_model("stock.quant.package")
-    def package(self, record, picking=None, with_packaging=False, **kw):
+    def package(self, record, picking=None, with_package_type=False, **kw):
         """Return data for a stock.quant.package
 
         If a picking is given, it will include the number of lines of the package
         for the picking.
         """
         parser = self._package_parser
-        if with_packaging:
-            parser += self._package_packaging_parser
+        if with_package_type:
+            parser += self._package_package_type_parser
         data = self._jsonify(record, parser, **kw)
         qty = len(record.quant_ids)
         # handle special cases
@@ -128,7 +128,6 @@ class DataAction(Component):
             "id",
             "name",
             "shopfloor_weight:weight",
-            ("package_type_id:storage_type", ["id", "name"]),
             (
                 "quant_ids:total_quantity",
                 lambda rec, fname: sum(rec.quant_ids.mapped("quantity")),
@@ -136,9 +135,9 @@ class DataAction(Component):
         ]
 
     @property
-    def _package_packaging_parser(self):
+    def _package_package_type_parser(self):
         return [
-            ("product_packaging_id:packaging", self._packaging_parser),
+            ("package_type_id:storage_type", self._package_type_parser),
         ]
 
     @ensure_model("product.packaging")
@@ -158,14 +157,14 @@ class DataAction(Component):
         ]
 
     @ensure_model("stock.package.type")
-    def delivery_packaging(self, record, **kw):
-        return self._jsonify(record, self._delivery_packaging_parser, **kw)
+    def package_type(self, record, **kw):
+        return self._jsonify(record, self._package_type_parser, **kw)
 
-    def delivery_packaging_list(self, records, **kw):
-        return self.delivery_packaging(records, multi=True)
+    def package_type_list(self, records, **kw):
+        return self.package_type(records, multi=True)
 
     @property
-    def _delivery_packaging_parser(self):
+    def _package_type_parser(self):
         return [
             "id",
             "name",

--- a/shopfloor/actions/data.py
+++ b/shopfloor/actions/data.py
@@ -137,7 +137,7 @@ class DataAction(Component):
     @property
     def _package_package_type_parser(self):
         return [
-            ("package_type_id:storage_type", self._package_type_parser),
+            ("package_type_id:package_type", self._package_type_parser),
         ]
 
     @ensure_model("product.packaging")

--- a/shopfloor/actions/data_detail.py
+++ b/shopfloor/actions/data_detail.py
@@ -96,7 +96,7 @@ class DataDetailAction(Component):
 
     def package_detail(self, record, picking=None, **kw):
         # Define a new method to not overload the base one which is used in many places
-        data = self.package(record, picking=picking, with_packaging=True, **kw)
+        data = self.package(record, picking=picking, with_package_type=True, **kw)
         data.update(self._jsonify(record, self._package_detail_parser, **kw))
         return data
 

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -922,13 +922,13 @@ class MessageAction(Component):
             "body": _("Package has been opened. You can move partial quantities."),
         }
 
-    def packaging_invalid_for_carrier(self, packaging, carrier):
+    def package_type_invalid_for_carrier(self, package_type, carrier):
         return {
             "message_type": "error",
             "body": _(
-                "Packaging '%(package_name)s' is not allowed for carrier "
+                "Package type '%(package_type_name)s' is not allowed for carrier "
                 "%(carrier_name)s.or carrier %(carrier_name)s.",
-                package_name=packaging.name if packaging else _("No value"),
+                package_type_name=package_type.name if package_type else _("No value"),
                 carrier_name=carrier.name,
             ),
         }
@@ -945,7 +945,7 @@ class MessageAction(Component):
             "body": _("No valid package to select."),
         }
 
-    def no_delivery_packaging_available(self):
+    def no_package_type_available(self):
         return {
             "message_type": "warning",
             "body": _("No delivery package type available."),

--- a/shopfloor/actions/packing.py
+++ b/shopfloor/actions/packing.py
@@ -1,55 +1,53 @@
 # Copyright 2021 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo.addons.component.core import Component
 
 
-class PackagingAction(Component):
-    """Provide methods to work with packaging operations."""
+class PackingAction(Component):
+    """Provide methods to work with packing operations."""
 
-    _name = "shopfloor.packaging.action"
+    _name = "shopfloor.packing.action"
     _inherit = "shopfloor.process.action"
-    _usage = "packaging"
+    _usage = "packing"
 
-    def packaging_valid_for_carrier(self, packaging, carrier):
-        return self.packaging_type_valid_for_carrier(packaging.package_type_id, carrier)
-
-    def packaging_type_valid_for_carrier(self, packaging_type, carrier):
-        return packaging_type.package_carrier_type in (
+    def package_type_valid_for_carrier(self, package_type, carrier):
+        return package_type.package_carrier_type in (
             "none",
             carrier.delivery_type,
         )
 
     def create_delivery_package(self, carrier):
-        default_packaging = self._get_default_packaging(carrier)
-        return self.create_package_from_packaging(default_packaging)
+        default_package_type = self._get_default_package_type(carrier)
+        return self.create_package_from_package_type(default_package_type)
 
-    def _get_default_packaging(self, carrier):
+    def _get_default_package_type(self, carrier):
         # TODO: refactor `delivery_[carrier_name]` modules
-        # to have always the same field named `default_packaging_id`
+        # to have always the same field named `default_package_type_id`
         # to unify lookup of this field.
         # As alternative add a computed field.
         # AFAIS there's no reason to have 1 field per carrier type.
-        fname = carrier.delivery_type + "_default_packaging_id"
+        fname = carrier.delivery_type + "_default_package_type_id"
         if fname not in carrier._fields:
             return self.env["stock.package.type"].browse()
         return carrier[fname]
 
-    def create_package_from_packaging(self, packaging=None):
-        if packaging:
-            vals = self._package_vals_from_packaging(packaging)
+    def create_package_from_package_type(self, package_type=None):
+        if package_type:
+            vals = self._package_vals_from_package_type(package_type)
         else:
-            vals = self._package_vals_without_packaging()
+            vals = self._package_vals_without_package_type()
         return self.env["stock.quant.package"].create(vals)
 
-    def _package_vals_from_packaging(self, packaging):
+    def _package_vals_from_package_type(self, package_type):
         return {
-            "package_type_id": packaging.id,
-            "pack_length": packaging.packaging_length,
-            "width": packaging.width,
-            "height": packaging.height,
+            "package_type_id": package_type.id,
+            "pack_length": package_type.packaging_length,
+            "width": package_type.width,
+            "height": package_type.height,
         }
 
-    def _package_vals_without_packaging(self):
+    def _package_vals_without_package_type(self):
         return {}
 
     def package_has_several_products(self, package):

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -29,7 +29,7 @@ class ShopfloorSchemaAction(Component):
             "priority": {"type": "string", "nullable": True, "required": False},
         }
 
-    def move_line(self, with_packaging=False, with_picking=False):
+    def move_line(self, with_package_type=False, with_picking=False):
         schema = {
             "id": {"type": "integer", "required": True},
             "qty_done": {"type": "float", "required": True},
@@ -42,10 +42,10 @@ class ShopfloorSchemaAction(Component):
                 "schema": self.lot(),
             },
             "package_src": self._schema_dict_of(
-                self.package(with_packaging=with_packaging)
+                self.package(with_package_type=with_package_type)
             ),
             "package_dest": self._schema_dict_of(
-                self.package(with_packaging=with_packaging), required=False
+                self.package(with_package_type=with_package_type), required=False
             ),
             "location_src": self._schema_dict_of(self.location()),
             "location_dest": self._schema_dict_of(self.location()),
@@ -85,13 +85,12 @@ class ShopfloorSchemaAction(Component):
             ),
         }
 
-    def package(self, with_packaging=False):
+    def package(self, with_package_type=False):
         schema = {
             "id": {"required": True, "type": "integer"},
             "name": {"type": "string", "nullable": False, "required": True},
             "weight": {"required": True, "nullable": True, "type": "float"},
             "move_line_count": {"required": False, "nullable": True, "type": "integer"},
-            "storage_type": self._schema_dict_of(self._simple_record()),
             "operation_progress": {
                 "type": "dict",
                 "required": False,
@@ -102,8 +101,8 @@ class ShopfloorSchemaAction(Component):
             },
             "total_quantity": {"required": False, "type": "float"},
         }
-        if with_packaging:
-            schema["packaging"] = self._schema_dict_of(self.packaging())
+        if with_package_type:
+            schema["storage_type"] = self._schema_dict_of(self.package_type())
         return schema
 
     def lot(self):
@@ -137,7 +136,7 @@ class ShopfloorSchemaAction(Component):
             "qty": {"type": "float", "required": True},
         }
 
-    def delivery_packaging(self):
+    def package_type(self):
         return {
             "id": {"required": True, "type": "integer"},
             "name": {"type": "string", "nullable": False, "required": True},

--- a/shopfloor/actions/schema.py
+++ b/shopfloor/actions/schema.py
@@ -102,7 +102,7 @@ class ShopfloorSchemaAction(Component):
             "total_quantity": {"required": False, "type": "float"},
         }
         if with_package_type:
-            schema["storage_type"] = self._schema_dict_of(self.package_type())
+            schema["package_type"] = self._schema_dict_of(self.package_type())
         return schema
 
     def lot(self):

--- a/shopfloor/actions/schema_detail.py
+++ b/shopfloor/actions/schema_detail.py
@@ -58,7 +58,7 @@ class ShopfloorSchemaDetailAction(Component):
         return schema
 
     def package_detail(self):
-        schema = self.package(with_packaging=True)
+        schema = self.package(with_package_type=True)
         schema.update(
             {
                 "pickings": self._schema_list_of(self.picking()),

--- a/shopfloor/actions/search.py
+++ b/shopfloor/actions/search.py
@@ -55,7 +55,7 @@ class SearchAction(Component):
             "lot": self.lot_from_scan,
             "serial": self.lot_from_scan,
             "packaging": self.packaging_from_scan,
-            "delivery_packaging": self.delivery_packaging_from_scan,
+            "package_type": self.package_type_from_scan,
             "origin_move": self.origin_move_from_scan,
         }
 
@@ -174,7 +174,7 @@ class SearchAction(Component):
             [("barcode", "=", barcode), ("product_id", "=", False)], limit=1
         )
 
-    def delivery_packaging_from_scan(self, barcode):
+    def package_type_from_scan(self, barcode):
         model = self.env["stock.package.type"]
         if not barcode:
             return model.browse()

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1,5 +1,5 @@
-# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
-# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from werkzeug.exceptions import BadRequest
@@ -143,7 +143,7 @@ class Checkout(Component):
         packages_data = self.data.packages(
             packages.with_context(picking_id=picking.id).sorted(),
             picking=picking,
-            with_packaging=True,
+            with_package_type=True,
             with_package_move_line_count=True,
         )
         return self._response(
@@ -156,34 +156,34 @@ class Checkout(Component):
             message=message,
         )
 
-    def _response_for_select_delivery_packaging(self, picking, packaging, message=None):
+    def _response_for_select_package_type(self, picking, package_type, message=None):
         return self._response(
-            next_state="select_delivery_packaging",
+            next_state="select_package_type",
             data={
                 # We don't need to send the 'picking' as the mobile frontend
                 # already has this info after `select_document` state
                 # TODO adapt other endpoints to see if we can get rid of the
                 # 'picking' data
-                "packaging": self._data_for_delivery_packaging(packaging),
+                "package_type": self._data_for_package_type(package_type),
             },
             message=message,
         )
 
-    def _response_for_change_packaging(self, picking, package, packaging_list):
+    def _response_for_change_package_type(self, picking, package, package_types):
         if not package:
             return self._response_for_summary(
                 picking, message=self.msg_store.record_not_found()
             )
 
         return self._response(
-            next_state="change_packaging",
+            next_state="change_package_type",
             data={
                 "picking": self.data.picking(picking),
                 "package": self.data.package(
-                    package, picking=picking, with_packaging=True
+                    package, picking=picking, with_package_type=True
                 ),
-                "packaging": self.data.delivery_packaging_list(
-                    packaging_list.sorted("sequence")
+                "package_type": self.data.package_type_list(
+                    package_types.sorted("sequence")
                 ),
             },
         )
@@ -338,8 +338,8 @@ class Checkout(Component):
     def _data_for_move_lines(self, lines, **kw):
         return self.data.move_lines(lines, **kw)
 
-    def _data_for_delivery_packaging(self, packaging, **kw):
-        return self.data.delivery_packaging_list(packaging, **kw)
+    def _data_for_package_type(self, package_type, **kw):
+        return self.data.package_type_list(package_type, **kw)
 
     def _data_for_stock_picking(
         self, picking, done=False, with_lines=True, with_location=False
@@ -351,7 +351,7 @@ class Checkout(Component):
                 {
                     "move_lines": self._data_for_move_lines(
                         self._lines_prepare(picking, line_picker(picking)),
-                        with_packaging=done,
+                        with_package_type=done,
                     )
                 }
             )
@@ -479,7 +479,7 @@ class Checkout(Component):
             "packaging": self._select_lines_from_packaging,
             "lot": self._select_lines_from_lot,
             "serial": self._select_lines_from_serial,
-            "delivery_packaging": self._select_lines_from_delivery_packaging,
+            "package_type": self._select_lines_from_package_type,
             "none": self._select_lines_from_none,
         }
         search_result = self._scan_line_find(picking, barcode, handlers.keys())
@@ -702,10 +702,10 @@ class Checkout(Component):
         return self._select_lines_from_lot(picking, selection_lines, lot, **kw)
 
     # Handling of the destination package scanned
-    def _select_lines_from_delivery_packaging(
-        self, picking, selection_lines, packaging, confirm_pack_all=None, **kw
+    def _select_lines_from_package_type(
+        self, picking, selection_lines, package_type, confirm_pack_all=None, **kw
     ):
-        """Handle delivery packaging.
+        """Handle package type.
 
         A delivery pkg has been scanned:
 
@@ -720,14 +720,14 @@ class Checkout(Component):
         carrier = self._get_carrier(picking)
         if carrier:
             # Validate against carrier
-            is_valid = self._packaging_good_for_carrier(packaging, carrier)
+            is_valid = self._package_type_good_for_carrier(package_type, carrier)
         else:
             is_valid = True
         if carrier and not is_valid:
             return self._response_for_select_line(
                 picking,
-                message=self.msg_store.packaging_invalid_for_carrier(
-                    packaging, carrier
+                message=self.msg_store.package_type_invalid_for_carrier(
+                    package_type, carrier
                 ),
             )
         message = None
@@ -738,10 +738,10 @@ class Checkout(Component):
         if not has_lines_to_pack:
             if self.work.menu.no_prefill_qty:
                 message = self.msg_store.no_lines_to_process_set_quantities()
-            elif confirm_pack_all != packaging.barcode:
-                need_confirm_pack_all = packaging.barcode
+            elif confirm_pack_all != package_type.barcode:
+                need_confirm_pack_all = package_type.barcode
                 message = self.msg_store.confirm_put_all_goods_in_delivery_package(
-                    packaging
+                    package_type
                 )
             if message:
                 return self._response_for_select_line(
@@ -749,10 +749,10 @@ class Checkout(Component):
                     message=message,
                     need_confirm_pack_all=need_confirm_pack_all,
                 )
-        if confirm_pack_all == packaging.barcode:
+        if confirm_pack_all == package_type.barcode:
             self._select_lines(selection_lines)
-        return self._create_and_assign_new_packaging(
-            picking, selection_lines, packaging=packaging
+        return self._create_and_assign_new_package_type(
+            picking, selection_lines, package_type=package_type
         )
 
     def _select_line_package(self, picking, selection_lines, package):
@@ -1006,9 +1006,11 @@ class Checkout(Component):
     def _post_put_lines_in_package(self, lines_packaged):
         """Hook to override."""
 
-    def _create_and_assign_new_packaging(self, picking, selected_lines, packaging=None):
-        actions = self._actions_for("packaging")
-        package = actions.create_package_from_packaging(packaging=packaging)
+    def _create_and_assign_new_package_type(
+        self, picking, selected_lines, package_type=None
+    ):
+        actions = self._actions_for("packing")
+        package = actions.create_package_from_package_type(package_type=package_type)
         return self._pack_lines(picking, selected_lines, package)
 
     def _pack_lines(self, picking, selected_lines, package):
@@ -1076,7 +1078,7 @@ class Checkout(Component):
             "packaging": self._scan_package_action_from_packaging,
             "lot": self._scan_package_action_from_lot,
             "serial": self._scan_package_action_from_serial,
-            "delivery_packaging": self._scan_package_action_from_delivery_packaging,
+            "package_type": self._scan_package_action_from_package_type,
         }
         search_result = self._scan_package_find(picking, barcode, handlers.keys())
         handler = handlers.get(search_result.type, self._scan_package_action_from_none)
@@ -1094,7 +1096,7 @@ class Checkout(Component):
             "packaging",
             "lot",
             "serial",
-            "delivery_packaging",
+            "package_type",
         )
         return search.find(
             barcode,
@@ -1165,24 +1167,26 @@ class Checkout(Component):
             )
         return self._put_lines_in_package(picking, selected_lines, package)
 
-    def _scan_package_action_from_delivery_packaging(
-        self, picking, selected_lines, packaging, **kw
+    def _scan_package_action_from_package_type(
+        self, picking, selected_lines, package_type, **kw
     ):
         carrier = self._get_carrier(picking)
         if carrier:
             # Validate against carrier
-            is_valid = self._packaging_type_good_for_carrier(packaging, carrier)
+            is_valid = self._package_type_good_for_carrier(package_type, carrier)
         else:
             is_valid = True
         if carrier and not is_valid:
             return self._response_for_select_package(
                 picking,
                 selected_lines,
-                message=self.msg_store.packaging_invalid_for_carrier(
-                    packaging, carrier
+                message=self.msg_store.package_type_invalid_for_carrier(
+                    package_type, carrier
                 ),
             )
-        return self._create_and_assign_new_packaging(picking, selected_lines, packaging)
+        return self._create_and_assign_new_package_type(
+            picking, selected_lines, package_type
+        )
 
     def _scan_package_action_from_none(self, picking, selected_lines, record, **kw):
         return self._response_for_select_package(
@@ -1192,48 +1196,47 @@ class Checkout(Component):
     def _get_carrier(self, picking):
         return picking.ship_carrier_id or picking.carrier_id
 
-    def _packaging_type_good_for_carrier(self, packaging, carrier):
-        actions = self._actions_for("packaging")
-        return actions.packaging_type_valid_for_carrier(packaging, carrier)
+    def _package_type_good_for_carrier(self, package_type, carrier):
+        actions = self._actions_for("packing")
+        return actions.package_type_valid_for_carrier(package_type, carrier)
 
-    def _packaging_good_for_carrier(self, packaging, carrier):
-        actions = self._actions_for("packaging")
-        return actions.packaging_valid_for_carrier(packaging, carrier)
-
-    def _get_available_delivery_packaging(self, picking):
+    def _get_available_package_type(self, picking):
         model = self.env["stock.package.type"]
         carrier = picking.ship_carrier_id or picking.carrier_id
         if not carrier:
-            return model.browse()
+            return model.search(
+                [("package_carrier_type", "=", False)],
+                order="name",
+            )
         return model.search(
             [("package_carrier_type", "=", carrier.delivery_type or "none")],
             order="name",
         )
 
-    def list_delivery_packaging(self, picking_id, selected_line_ids):
-        """List available delivery packaging for given picking.
+    def list_package_type(self, picking_id, selected_line_ids):
+        """List available package type for given picking.
 
         Transitions:
-        * select_delivery_packaging: list available delivery packaging, the
+        * select_package_type: list available package type, the
         user has to choose one to create the new package
-        * select_package: when no delivery packaging is available
+        * select_package: when no package type is available
         """
         picking = self.env["stock.picking"].browse(picking_id)
         message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
-        delivery_packaging = self._get_available_delivery_packaging(picking)
-        if not delivery_packaging:
+        package_type = self._get_available_package_type(picking)
+        if not package_type:
             return self._response_for_select_package(
                 picking,
                 selected_lines,
-                message=self.msg_store.no_delivery_packaging_available(),
+                message=self.msg_store.no_package_type_available(),
             )
         response = self._check_allowed_qty_picked(picking, selected_lines)
         if response:
             return response
-        return self._response_for_select_delivery_packaging(picking, delivery_packaging)
+        return self._response_for_select_package_type(picking, package_type)
 
     def new_package(self, picking_id, selected_line_ids, package_type_id=None):
         """Add all selected lines in a new package
@@ -1252,11 +1255,16 @@ class Checkout(Component):
         message = self._check_picking_processible(picking)
         if message:
             return self._response_for_select_document(message=message)
-        packaging = None
         if package_type_id:
-            packaging = self.env["stock.package.type"].browse(package_type_id).exists()
+            package_type = (
+                self.env["stock.package.type"].browse(package_type_id).exists()
+            )
+        else:
+            package_type = None
         selected_lines = self.env["stock.move.line"].browse(selected_line_ids).exists()
-        return self._create_and_assign_new_packaging(picking, selected_lines, packaging)
+        return self._create_and_assign_new_package_type(
+            picking, selected_lines, package_type
+        )
 
     def no_package(self, picking_id, selected_line_ids):
         """Process all selected lines without any package.
@@ -1410,17 +1418,16 @@ class Checkout(Component):
             return self._response_for_select_document(message=message)
         return self._response_for_summary(picking)
 
-    def _get_allowed_packaging(self):
-        return self.env["stock.package.type"].search([])
+    def _get_allowed_package_type(self):
+        return self.env["stock.package.type"].search(
+            [("package_carrier_type", "!=", False)]
+        )
 
-    def list_packaging(self, picking_id, package_id):
-        """List the available package types for a package
-
-        For a package, we can change the packaging. The available
-        packaging are the ones with no product.
+    def change_list_package_type(self, picking_id, package_id):
+        """List the available package types for a package in order to change it.
 
         Transitions:
-        * change_packaging
+        * change_package_type
         * summary: if the package_id no longer exists
         """
         picking = self.env["stock.picking"].browse(picking_id)
@@ -1428,14 +1435,14 @@ class Checkout(Component):
         if message:
             return self._response_for_select_document(message=message)
         package = self.env["stock.quant.package"].browse(package_id).exists()
-        packaging_list = self._get_allowed_packaging()
-        return self._response_for_change_packaging(picking, package, packaging_list)
+        package_types = self._get_available_package_type(picking)
+        return self._response_for_change_package_type(picking, package, package_types)
 
-    def set_packaging(self, picking_id, package_id, package_type_id):
+    def change_set_package_type(self, picking_id, package_id, package_type_id):
         """Set a package type on a package
 
         Transitions:
-        * change_packaging: in case of error
+        * change_package_type: in case of error
         * summary
         """
         picking = self.env["stock.picking"].browse(picking_id)
@@ -1444,17 +1451,17 @@ class Checkout(Component):
             return self._response_for_select_document(message=message)
 
         package = self.env["stock.quant.package"].browse(package_id).exists()
-        packaging = self.env["stock.package.type"].browse(package_type_id).exists()
-        if not (package and packaging):
+        package_type = self.env["stock.package.type"].browse(package_type_id).exists()
+        if not (package and package_type):
             return self._response_for_summary(
                 picking, message=self.msg_store.record_not_found()
             )
-        package.package_type_id = packaging
+        package.package_type_id = package_type
         return self._response_for_summary(
             picking,
             message={
                 "message_type": "success",
-                "body": _("Packaging changed on package {}").format(package.name),
+                "body": _("Package type changed on package {}").format(package.name),
             },
         )
 
@@ -1679,7 +1686,7 @@ class ShopfloorCheckoutValidator(Component):
             "barcode": {"required": True, "type": "string"},
         }
 
-    def list_delivery_packaging(self):
+    def list_package_type(self):
         return {
             "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
             "selected_line_ids": {
@@ -1742,13 +1749,13 @@ class ShopfloorCheckoutValidator(Component):
     def summary(self):
         return {"picking_id": {"coerce": to_int, "required": True, "type": "integer"}}
 
-    def list_packaging(self):
+    def change_list_package_type(self):
         return {
             "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
             "package_id": {"coerce": to_int, "required": True, "type": "integer"},
         }
 
-    def set_packaging(self):
+    def change_set_package_type(self):
         return {
             "picking_id": {"coerce": to_int, "required": True, "type": "integer"},
             "package_id": {"coerce": to_int, "required": True, "type": "integer"},
@@ -1825,9 +1832,9 @@ class ShopfloorCheckoutValidatorResponse(Component):
             ),
             "change_quantity": self._schema_selected_lines,
             "select_dest_package": self._schema_select_package,
-            "select_delivery_packaging": self._schema_select_delivery_packaging,
+            "select_package_type": self._schema_select_package_type,
             "summary": self._schema_summary,
-            "change_packaging": self._schema_select_packaging,
+            "change_package_type": self._schema_change_package_type,
             "confirm_done": self._schema_confirm_done,
             "select_child_location": self._schema_select_child_location,
         }
@@ -1842,12 +1849,12 @@ class ShopfloorCheckoutValidatorResponse(Component):
             },
         }
 
-    def _schema_stock_picking(self, lines_with_packaging=False):
+    def _schema_stock_picking(self, lines_with_package_type=False):
         schema = self.schemas.picking()
         schema.update(
             {
                 "move_lines": self.schemas._schema_list_of(
-                    self.schemas.move_line(with_packaging=lines_with_packaging)
+                    self.schemas.move_line(with_package_type=lines_with_package_type)
                 )
             }
         )
@@ -1866,13 +1873,13 @@ class ShopfloorCheckoutValidatorResponse(Component):
     @property
     def _schema_summary(self):
         return dict(
-            self._schema_stock_picking(lines_with_packaging=True),
+            self._schema_stock_picking(lines_with_package_type=True),
             all_processed={"type": "boolean"},
         )
 
     @property
     def _schema_confirm_done(self):
-        return self._schema_stock_picking(lines_with_packaging=True)
+        return self._schema_stock_picking(lines_with_package_type=True)
 
     @property
     def _schema_select_child_location(self):
@@ -1900,31 +1907,29 @@ class ShopfloorCheckoutValidatorResponse(Component):
                 "type": "list",
                 "schema": {
                     "type": "dict",
-                    "schema": self.schemas.package(with_packaging=True),
+                    "schema": self.schemas.package(with_package_type=True),
                 },
             },
             "picking": {"type": "dict", "schema": self.schemas.picking()},
         }
 
     @property
-    def _schema_select_delivery_packaging(self):
+    def _schema_select_package_type(self):
         return {
-            "packaging": self.schemas._schema_list_of(
-                self.schemas.delivery_packaging()
-            ),
+            "package_type": self.schemas._schema_list_of(self.schemas.package_type()),
         }
 
     @property
-    def _schema_select_packaging(self):
+    def _schema_change_package_type(self):
         return {
             "picking": {"type": "dict", "schema": self.schemas.picking()},
             "package": {
                 "type": "dict",
-                "schema": self.schemas.package(with_packaging=True),
+                "schema": self.schemas.package(with_package_type=True),
             },
-            "packaging": {
+            "package_type": {
                 "type": "list",
-                "schema": {"type": "dict", "schema": self.schemas.delivery_packaging()},
+                "schema": {"type": "dict", "schema": self.schemas.package_type()},
             },
         }
 
@@ -1973,9 +1978,9 @@ class ShopfloorCheckoutValidatorResponse(Component):
             next_states={"select_package", "select_line", "summary"}
         )
 
-    def list_delivery_packaging(self):
+    def list_package_type(self):
         return self._response_schema(
-            next_states={"select_delivery_packaging", "select_package"}
+            next_states={"select_package_type", "select_package"}
         )
 
     def new_package(self):
@@ -2012,11 +2017,11 @@ class ShopfloorCheckoutValidatorResponse(Component):
     def summary(self):
         return self._response_schema(next_states={"summary"})
 
-    def list_packaging(self):
-        return self._response_schema(next_states={"change_packaging", "summary"})
+    def change_list_package_type(self):
+        return self._response_schema(next_states={"change_package_type", "summary"})
 
-    def set_packaging(self):
-        return self._response_schema(next_states={"change_packaging", "summary"})
+    def change_set_package_type(self):
+        return self._response_schema(next_states={"change_package_type", "summary"})
 
     def cancel_line(self):
         return self._response_schema(next_states={"summary", "select_line"})

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1,5 +1,5 @@
-# Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
-# Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import functools
@@ -166,10 +166,9 @@ class ZonePicking(Component):
         return self.work.menu.require_destination_package
 
     def _handle_complete_mix_pack(self, package):
-        packaging = self._actions_for("packaging")
+        packing = self._actions_for("packing")
         return (
-            packaging.is_complete_mix_pack(package)
-            and not self.work.menu.no_prefill_qty
+            packing.is_complete_mix_pack(package) and not self.work.menu.no_prefill_qty
         )
 
     def _response_for_start(self, message=None):
@@ -619,7 +618,7 @@ class ZonePicking(Component):
         message = None
         response = None
         search = self._actions_for("search")
-        packaging = self._actions_for("packaging")
+        packing = self._actions_for("packing")
         package = search.package_from_scan(barcode)
         if not package:
             return response, message
@@ -640,9 +639,9 @@ class ZonePicking(Component):
                     first(move_lines), qty_done=0
                 )
                 return response, message
-            if packaging.package_has_several_products(package):
+            if packing.package_has_several_products(package):
                 message = self.msg_store.several_products_in_package(package)
-            if packaging.package_has_several_lots(package):
+            if packing.package_has_several_lots(package):
                 message = self.msg_store.several_lots_in_package(package)
             if message or self.work.menu.no_prefill_qty:
                 return (
@@ -1285,7 +1284,7 @@ class ZonePicking(Component):
         picking = move_line.picking_id
         carrier = picking.ship_carrier_id or picking.carrier_id
         if carrier:
-            actions = self._actions_for("packaging")
+            actions = self._actions_for("packing")
             pkg = actions.create_delivery_package(carrier)
             move_line.write({"result_package_id": pkg.id})
             message = self.msg_store.goods_packed_in(pkg)
@@ -1306,14 +1305,12 @@ class ZonePicking(Component):
         picking = move_line.picking_id
         carrier = picking.ship_carrier_id or picking.carrier_id
         if carrier:
-            actions = self._actions_for("packaging")
-            if actions.packaging_valid_for_carrier(
-                package.product_packaging_id, carrier
-            ):
+            actions = self._actions_for("packing")
+            if actions.package_type_valid_for_carrier(package.package_type_id, carrier):
                 good_for_packing = True
             else:
-                message = self.msg_store.packaging_invalid_for_carrier(
-                    package.product_packaging_id, carrier
+                message = self.msg_store.package_type_invalid_for_carrier(
+                    package.package_type_id, carrier
                 )
         else:
             message = self.msg_store.picking_without_carrier_cannot_pack(picking)

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -4,6 +4,7 @@ from . import test_openapi
 from . import test_actions_change_package_lot
 from . import test_actions_data
 from . import test_actions_data_detail
+from . import test_actions_packing
 from . import test_actions_search_move_line
 from . import test_actions_search
 from . import test_actions_stock
@@ -38,10 +39,10 @@ from . import test_checkout_scan_package_action_no_prefill_qty
 from . import test_checkout_new_package
 from . import test_checkout_no_package
 from . import test_checkout_auto_post
-from . import test_checkout_list_delivery_packaging
+from . import test_checkout_list_package_type
 from . import test_checkout_list_package
 from . import test_checkout_summary
-from . import test_checkout_change_packaging
+from . import test_checkout_change_package_type
 from . import test_checkout_cancel_line
 from . import test_checkout_done
 from . import test_delivery_base

--- a/shopfloor/tests/models.py
+++ b/shopfloor/tests/models.py
@@ -17,7 +17,7 @@ class DeliveryCarrierTest(models.Model):
     delivery_type = fields.Selection(
         selection_add=[("test", "TEST")], ondelete={"test": "set default"}
     )
-    test_default_packaging_id = fields.Many2one(
+    test_default_package_type_id = fields.Many2one(
         "stock.package.type", string="Default Package Type"
     )
 

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -13,12 +13,10 @@ class ActionsDataCase(ActionsDataCaseBase):
         self.assert_schema(self.schema.packaging(), data)
         self.assertDictEqual(data, self._expected_packaging(self.packaging))
 
-    def test_data_delivery_packaging(self):
-        data = self.data.delivery_packaging(self.delivery_packaging)
-        self.assert_schema(self.schema.delivery_packaging(), data)
-        self.assertDictEqual(
-            data, self._expected_delivery_packaging(self.delivery_packaging)
-        )
+    def test_data_package_type(self):
+        data = self.data.package_type(self.package_type)
+        self.assert_schema(self.schema.package_type(), data)
+        self.assertDictEqual(data, self._expected_package_type(self.package_type))
 
     def test_data_location(self):
         location = self.stock_location
@@ -81,13 +79,12 @@ class ActionsDataCase(ActionsDataCaseBase):
         package = self.move_a.move_line_ids.package_id
         package.product_packaging_id = self.packaging.id
         package.package_type_id = self.storage_type_pallet
-        data = self.data.package(package, picking=self.picking, with_packaging=True)
-        self.assert_schema(self.schema.package(with_packaging=True), data)
+        data = self.data.package(package, picking=self.picking, with_package_type=True)
+        self.assert_schema(self.schema.package(with_package_type=True), data)
         expected = {
             "id": package.id,
             "name": package.name,
-            "packaging": self._expected_packaging(package.product_packaging_id),
-            "storage_type": self._expected_storage_type(package.package_type_id),
+            "storage_type": self._expected_package_type(package.package_type_id),
             "total_quantity": 10.0,
             "weight": 20.0,
         }
@@ -95,21 +92,19 @@ class ActionsDataCase(ActionsDataCaseBase):
 
     def test_data_package_with_move_line_count(self):
         package = self.move_a.move_line_ids.package_id
-        package.product_packaging_id = self.packaging.id
         package.package_type_id = self.storage_type_pallet
         data = self.data.package(
             package,
             picking=self.picking,
-            with_packaging=True,
+            with_package_type=True,
             with_package_move_line_count=True,
         )
-        self.assert_schema(self.schema.package(with_packaging=True), data)
+        self.assert_schema(self.schema.package(with_package_type=True), data)
         expected = {
             "id": package.id,
             "name": package.name,
             "move_line_count": 2,
-            "packaging": self._expected_packaging(package.product_packaging_id),
-            "storage_type": self._expected_storage_type(package.package_type_id),
+            "storage_type": self._expected_package_type(package.package_type_id),
             "weight": 20.0,
             "total_quantity": sum(package.quant_ids.mapped("quantity")),
         }
@@ -232,7 +227,6 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
                 "weight": move_line.package_id.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.package_id.quant_ids.mapped("quantity")
                 ),
@@ -241,7 +235,6 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "id": result_package.id,
                 "name": result_package.name,
                 "weight": move_line.package_id.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(result_package.quant_ids.mapped("quantity")),
             },
             "location_src": self._expected_location(move_line.location_id),
@@ -297,7 +290,6 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
                 "weight": 30.0,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.package_id.quant_ids.mapped("quantity")
                 ),
@@ -306,7 +298,6 @@ class ActionsDataCase(ActionsDataCaseBase):
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
                 "weight": 30.0,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.result_package_id.quant_ids.mapped("quantity")
                 ),

--- a/shopfloor/tests/test_actions_data.py
+++ b/shopfloor/tests/test_actions_data.py
@@ -78,13 +78,13 @@ class ActionsDataCase(ActionsDataCaseBase):
     def test_data_package(self):
         package = self.move_a.move_line_ids.package_id
         package.product_packaging_id = self.packaging.id
-        package.package_type_id = self.storage_type_pallet
+        package.package_type_id = self.package_type_pallet
         data = self.data.package(package, picking=self.picking, with_package_type=True)
         self.assert_schema(self.schema.package(with_package_type=True), data)
         expected = {
             "id": package.id,
             "name": package.name,
-            "storage_type": self._expected_package_type(package.package_type_id),
+            "package_type": self._expected_package_type(package.package_type_id),
             "total_quantity": 10.0,
             "weight": 20.0,
         }
@@ -92,7 +92,7 @@ class ActionsDataCase(ActionsDataCaseBase):
 
     def test_data_package_with_move_line_count(self):
         package = self.move_a.move_line_ids.package_id
-        package.package_type_id = self.storage_type_pallet
+        package.package_type_id = self.package_type_pallet
         data = self.data.package(
             package,
             picking=self.picking,
@@ -104,7 +104,7 @@ class ActionsDataCase(ActionsDataCaseBase):
             "id": package.id,
             "name": package.name,
             "move_line_count": 2,
-            "storage_type": self._expected_package_type(package.package_type_id),
+            "package_type": self._expected_package_type(package.package_type_id),
             "weight": 20.0,
             "total_quantity": sum(package.quant_ids.mapped("quantity")),
         }

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -39,7 +39,7 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
                 }
             )
         )
-        cls.delivery_packaging = (
+        cls.package_type = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -160,20 +160,12 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
         data.update(kw)
         return data
 
-    def _expected_delivery_packaging(self, record, **kw):
+    def _expected_package_type(self, record, **kw):
         data = {
             "id": record.id,
             "name": record.name,
             "packaging_type": record.package_carrier_type,
-            "barcode": record.barcode,
-        }
-        data.update(kw)
-        return data
-
-    def _expected_storage_type(self, record, **kw):
-        data = {
-            "id": record.id,
-            "name": record.name,
+            "barcode": record.barcode or None,
         }
         data.update(kw)
         return data
@@ -183,7 +175,6 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
             "id": record.id,
             "name": record.name,
             "weight": record.shopfloor_weight,
-            "storage_type": None,
             "total_quantity": sum(record.quant_ids.mapped("quantity")),
         }
         data.update(kw)

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -16,7 +16,7 @@ class ActionsDataCaseBase(CommonCase, ActionsDataTestMixin):
         super().setUpClassVars()
         cls.wh = cls.env.ref("stock.warehouse0")
         cls.picking_type = cls.wh.out_type_id
-        cls.storage_type_pallet = cls.env.ref(
+        cls.package_type_pallet = cls.env.ref(
             "stock_storage_type.package_storage_type_pallets"
         )
 
@@ -203,7 +203,7 @@ class ActionsDataDetailCaseBase(ActionsDataCaseBase):
     @classmethod
     def setUpClassVars(cls):
         super().setUpClassVars()
-        cls.storage_type_pallet = cls.env.ref(
+        cls.package_type_pallet = cls.env.ref(
             "stock_storage_type.package_storage_type_pallets"
         )
 

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -66,7 +66,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
 
     def test_data_package(self):
         package = self.move_a.move_line_ids.package_id
-        package.product_packaging_id = self.packaging.id
         package.package_type_id = self.storage_type_pallet
         # package.invalidate_recordset()
         data = self.data_detail.package_detail(package, picking=self.picking)
@@ -83,13 +82,14 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "name": package.location_id.display_name,
             },
             "name": package.name,
-            "packaging": self.data_detail.packaging(package.product_packaging_id),
             "weight": 20.0,
             "pickings": self.data_detail.pickings(pickings),
             "move_lines": self.data_detail.move_lines(lines),
             "storage_type": {
                 "id": self.storage_type_pallet.id,
                 "name": self.storage_type_pallet.name,
+                "packaging_type": "none",
+                "barcode": None,
             },
             "total_quantity": sum(package.quant_ids.mapped("quantity")),
         }
@@ -196,7 +196,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
                 "weight": move_line.package_id.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.package_id.quant_ids.mapped("quantity")
                 ),
@@ -205,7 +204,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "id": result_package.id,
                 "name": result_package.name,
                 "weight": result_package.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.result_package_id.quant_ids.mapped("quantity")
                 ),
@@ -264,7 +262,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "id": move_line.package_id.id,
                 "name": move_line.package_id.name,
                 "weight": move_line.package_id.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.package_id.quant_ids.mapped("quantity")
                 ),
@@ -273,7 +270,6 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
                 "id": move_line.result_package_id.id,
                 "name": move_line.result_package_id.name,
                 "weight": move_line.result_package_id.shopfloor_weight,
-                "storage_type": None,
                 "total_quantity": sum(
                     move_line.result_package_id.quant_ids.mapped("quantity")
                 ),

--- a/shopfloor/tests/test_actions_data_detail.py
+++ b/shopfloor/tests/test_actions_data_detail.py
@@ -66,7 +66,7 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
 
     def test_data_package(self):
         package = self.move_a.move_line_ids.package_id
-        package.package_type_id = self.storage_type_pallet
+        package.package_type_id = self.package_type_pallet
         # package.invalidate_recordset()
         data = self.data_detail.package_detail(package, picking=self.picking)
         self.assert_schema(self.schema_detail.package_detail(), data)
@@ -85,9 +85,9 @@ class TestActionsDataDetailCase(ActionsDataDetailCaseBase):
             "weight": 20.0,
             "pickings": self.data_detail.pickings(pickings),
             "move_lines": self.data_detail.move_lines(lines),
-            "storage_type": {
-                "id": self.storage_type_pallet.id,
-                "name": self.storage_type_pallet.name,
+            "package_type": {
+                "id": self.package_type_pallet.id,
+                "name": self.package_type_pallet.name,
                 "packaging_type": "none",
                 "barcode": None,
             },

--- a/shopfloor/tests/test_actions_packing.py
+++ b/shopfloor/tests/test_actions_packing.py
@@ -7,14 +7,14 @@
 from .common import CommonCase
 
 
-class TestActionsPackaging(CommonCase):
-    """Tests covering methods to work on product packaging."""
+class TestActionsPacking(CommonCase):
+    """Tests covering methods to work on package type."""
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         with cls.work_on_actions(cls) as work:
-            cls.packaging = work.component(usage="packaging")
+            cls.packing = work.component(usage="packing")
         cls.picking = cls._create_picking(
             lines=[(cls.product_a, 10), (cls.product_b, 10)], confirm=True
         )
@@ -33,11 +33,11 @@ class TestActionsPackaging(CommonCase):
         cls.picking_type = cls.wh.out_type_id
 
     def test_package_is_complete_mix_pack(self):
-        self.assertTrue(self.packaging.is_complete_mix_pack(self.package1))
+        self.assertTrue(self.packing.is_complete_mix_pack(self.package1))
 
     def test_package_partially_reserved(self):
         # Package has 2 products from pick 1 reserved
         pick2 = self._create_picking(lines=[(self.product_c, 10)], confirm=True)
         # But adding 1 more product from pick 2 that is not yet reserved
         self._fill_stock_for_moves(pick2.move_ids, in_package=self.package1)
-        self.assertFalse(self.packaging.is_complete_mix_pack(self.package1))
+        self.assertFalse(self.packing.is_complete_mix_pack(self.package1))

--- a/shopfloor/tests/test_checkout_auto_post.py
+++ b/shopfloor/tests/test_checkout_auto_post.py
@@ -32,7 +32,7 @@ class CheckoutAutoPostCase(CheckoutCommonCase):
             params={
                 "picking_id": picking.id,
                 "selected_line_ids": [selected_move_line_a.id, selected_move_line_b.id],
-                "barcode": self.delivery_packaging.barcode,
+                "barcode": self.package_type.barcode,
             },
         )
 

--- a/shopfloor/tests/test_checkout_base.py
+++ b/shopfloor/tests/test_checkout_base.py
@@ -19,7 +19,7 @@ class CheckoutCommonCase(CommonCase):
     def setUpClassBaseData(cls, *args, **kwargs):
         super().setUpClassBaseData(*args, **kwargs)
         cls.wh.sudo().delivery_steps = "pick_pack_ship"
-        cls.delivery_packaging = (
+        cls.package_type = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -56,11 +56,11 @@ class CheckoutCommonCase(CommonCase):
 
     def _package_data(self, package, picking, **kwargs):
         return self.data.package(
-            package, picking=picking, with_packaging=True, **kwargs
+            package, picking=picking, with_package_type=True, **kwargs
         )
 
-    def _packaging_data(self, packaging):
-        return self.data.delivery_packaging(packaging)
+    def _package_type_data(self, package_type):
+        return self.data.package_type(package_type)
 
     def _data_for_select_line(self, picking, **kw):
         data = {

--- a/shopfloor/tests/test_checkout_change_package_type.py
+++ b/shopfloor/tests/test_checkout_change_package_type.py
@@ -4,68 +4,53 @@ from .test_checkout_base import CheckoutCommonCase
 
 
 # pylint: disable=missing-return
-class CheckoutListSetPackagingCase(CheckoutCommonCase):
+class CheckoutListSetPackageTypeCase(CheckoutCommonCase):
     @classmethod
     def setUpClassBaseData(cls):
         super().setUpClassBaseData()
         cls.env["stock.package.type"].sudo().search([]).active = False
-        pallet_type = (
-            cls.env["product.packaging.level"]
-            .sudo()
-            .create({"name": "Pallet", "code": "P", "sequence": 3})
-        )
-        cls.packaging_pallet = (
+        cls.package_type_pallet = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
                 {
-                    "packaging_level_id": pallet_type.id,
                     "name": "Pallet",
                     "barcode": "PPP",
                     "height": 100,
                     "width": 100,
                     "packaging_length": 100,
                     "sequence": 2,
+                    "package_carrier_type": False,  # no carrier set on picking
                 }
             )
         )
-        box_type = (
-            cls.env["product.packaging.level"]
-            .sudo()
-            .create({"name": "Box", "code": "B", "sequence": 2})
-        )
-        cls.packaging_box = (
+        cls.package_type_box = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
                 {
-                    "packaging_level_id": box_type.id,
                     "name": "Box",
                     "barcode": "BBB",
                     "height": 20,
                     "width": 20,
                     "packaging_length": 20,
                     "sequence": 1,
+                    "package_carrier_type": False,  # no carrier set on picking
                 }
             )
         )
-        inner_box_type = (
-            cls.env["product.packaging.level"]
-            .sudo()
-            .create({"name": "Inner Box", "code": "I", "sequence": 1})
-        )
-        cls.packaging_inner_box = (
+        cls.package_type_inner_box = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
                 {
-                    "packaging_level_id": inner_box_type.id,
                     "name": "Inner Box",
                     "barcode": "III",
                     "height": 10,
                     "width": 10,
                     "packaging_length": 10,
                     "sequence": 0,
+                    "package_carrier_type": False,  # no carrier set on picking
                 }
             )
         )
@@ -73,33 +58,34 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
         cls._fill_stock_for_moves(cls.picking.move_ids, in_package=True)
         cls.picking.action_assign()
         cls.package = cls.picking.move_line_ids.result_package_id
-        cls.package.package_type_id = cls.packaging_pallet
-        cls.packagings = cls.env["stock.package.type"].search([]).sorted()
+        cls.package.package_type_id = cls.package_type_pallet
+        cls.package_types = cls.env["stock.package.type"].search([]).sorted()
 
-    def test_list_packaging_ok(self):
+    def test_list_package_type_ok(self):
         response = self.service.dispatch(
-            "list_packaging",
+            "change_list_package_type",
             params={"picking_id": self.picking.id, "package_id": self.package.id},
         )
 
         self.assert_response(
             response,
-            next_state="change_packaging",
+            next_state="change_package_type",
             data={
                 "picking": self._picking_summary_data(self.picking),
                 "package": self._package_data(self.package, self.picking),
-                "packaging": [
-                    self._packaging_data(packaging)
-                    for packaging in self.packaging_inner_box
-                    + self.packaging_box
-                    + self.packaging_pallet
+                "package_type": [
+                    self._package_type_data(package_type)
+                    for package_type in self.package_type_inner_box
+                    + self.package_type_box
+                    + self.package_type_pallet
                 ],
             },
         )
 
-    def test_list_packaging_error_package_not_found(self):
+    def test_list_package_type_error_package_not_found(self):
         response = self.service.dispatch(
-            "list_packaging", params={"picking_id": self.picking.id, "package_id": 0}
+            "change_list_package_type",
+            params={"picking_id": self.picking.id, "package_id": 0},
         )
         self.assert_response(
             response,
@@ -114,17 +100,17 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
             },
         )
 
-    def test_set_packaging_ok(self):
+    def test_set_package_type_ok(self):
         response = self.service.dispatch(
-            "set_packaging",
+            "change_set_package_type",
             params={
                 "picking_id": self.picking.id,
                 "package_id": self.package.id,
-                "package_type_id": self.packaging_inner_box.id,
+                "package_type_id": self.package_type_inner_box.id,
             },
         )
         self.assertRecordValues(
-            self.package, [{"package_type_id": self.packaging_inner_box.id}]
+            self.package, [{"package_type_id": self.package_type_inner_box.id}]
         )
         self.assert_response(
             response,
@@ -135,17 +121,17 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
             },
             message={
                 "message_type": "success",
-                "body": f"Packaging changed on package {self.package.name}",
+                "body": f"Package type changed on package {self.package.name}",
             },
         )
 
-    def test_set_packaging_error_package_not_found(self):
+    def test_set_package_type_error_package_not_found(self):
         response = self.service.dispatch(
-            "set_packaging",
+            "change_set_package_type",
             params={
                 "picking_id": self.picking.id,
                 "package_id": 0,
-                "package_type_id": self.packaging_inner_box.id,
+                "package_type_id": self.package_type_inner_box.id,
             },
         )
         self.assert_response(
@@ -161,9 +147,9 @@ class CheckoutListSetPackagingCase(CheckoutCommonCase):
             },
         )
 
-    def test_set_packaging_error_packaging_not_found(self):
+    def test_set_package_type_error_package_type_not_found(self):
         response = self.service.dispatch(
-            "set_packaging",
+            "change_set_package_type",
             params={
                 "picking_id": self.picking.id,
                 "package_id": self.package.id,

--- a/shopfloor/tests/test_checkout_list_package.py
+++ b/shopfloor/tests/test_checkout_list_package.py
@@ -58,11 +58,11 @@ class CheckoutListDestPackageCase(
         self._fill_stock_for_moves(picking.move_ids[2], in_package=True)
         self._fill_stock_for_moves(picking.move_ids[3], in_package=True)
         picking.action_assign()
-        delivery_packaging = self.env.ref(
+        package_type = self.env.ref(
             "stock_storage_type.product_product_9_packaging_single_bag"
         )
         delivery_package = self.env["stock.quant.package"].create(
-            {"package_type_id": delivery_packaging.id}
+            {"package_type_id": package_type.id}
         )
         picking.move_ids[1].move_line_ids.result_package_id = delivery_package
         response = self.service.dispatch(
@@ -123,11 +123,11 @@ class CheckoutScanSetDestPackageCase(CheckoutCommonCase, SelectDestPackageMixin)
 
         cls.selected_lines = pack1_moves.move_line_ids
         cls.pack1 = pack1_moves.move_line_ids.package_id
-        cls.delivery_packaging = cls.env.ref(
+        cls.package_type = cls.env.ref(
             "stock_storage_type.product_product_9_packaging_single_bag"
         )
         cls.delivery_package = cls.env["stock.quant.package"].create(
-            {"package_type_id": cls.delivery_packaging.id}
+            {"package_type_id": cls.package_type.id}
         )
         cls.move_line1, cls.move_line2, cls.move_line3 = cls.selected_lines
         # The 'scan_dest_package' and 'set_dest_package' methods can not be

--- a/shopfloor/tests/test_checkout_list_package_type.py
+++ b/shopfloor/tests/test_checkout_list_package_type.py
@@ -53,7 +53,7 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
             .sudo()
             .create({"name": "Transport Box", "code": "TB", "sequence": 0})
         )
-        cls.delivery_packaging1 = (
+        cls.package_type1 = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -64,7 +64,7 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
                 }
             )
         )
-        cls.delivery_packaging2 = (
+        cls.package_type2 = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -75,16 +75,14 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
                 }
             )
         )
-        cls.delivery_packaging = (
-            cls.delivery_packaging1 | cls.delivery_packaging2
-        ).sorted("name")
+        cls.package_type = (cls.package_type1 | cls.package_type2).sorted("name")
 
-    def test_list_delivery_packaging_available(self):
+    def test_list_package_type_available(self):
         self._fill_stock_for_moves(self.picking.move_ids, in_package=True)
         self.picking.action_assign()
         selected_lines = self.picking.move_line_ids
         response = self.service.dispatch(
-            "list_delivery_packaging",
+            "list_package_type",
             params={
                 "picking_id": self.picking.id,
                 "selected_line_ids": selected_lines.ids,
@@ -92,21 +90,19 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
         )
         self.assert_response(
             response,
-            next_state="select_delivery_packaging",
+            next_state="select_package_type",
             data={
-                "packaging": self.service.data.delivery_packaging_list(
-                    self.delivery_packaging
-                ),
+                "package_type": self.service.data.package_type_list(self.package_type),
             },
         )
 
-    def test_list_delivery_packaging_not_available(self):
-        self.delivery_packaging.package_carrier_type = False
+    def test_list_package_type_not_available(self):
+        self.package_type.package_carrier_type = False
         self._fill_stock_for_moves(self.picking.move_ids, in_package=True)
         self.picking.action_assign()
         selected_lines = self.picking.move_line_ids
         response = self.service.dispatch(
-            "list_delivery_packaging",
+            "list_package_type",
             params={
                 "picking_id": self.picking.id,
                 "selected_line_ids": selected_lines.ids,
@@ -126,5 +122,5 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
                 ),
                 "package_allowed": True,
             },
-            message=self.service.msg_store.no_delivery_packaging_available(),
+            message=self.service.msg_store.no_package_type_available(),
         )

--- a/shopfloor/tests/test_checkout_scan_line.py
+++ b/shopfloor/tests/test_checkout_scan_line.py
@@ -9,7 +9,7 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
     @classmethod
     def setUpClassBaseData(cls, *args, **kwargs):
         super().setUpClassBaseData(*args, **kwargs)
-        cls.delivery_packaging = (
+        cls.package_type = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -419,24 +419,22 @@ class CheckoutScanLineCase(CheckoutScanLineCaseBase):
             "scan_line",
             params={
                 "picking_id": picking.id,
-                "barcode": self.delivery_packaging.barcode,
+                "barcode": self.package_type.barcode,
             },
         )
         # back to same state
         self.assertEqual(response["next_state"], "select_line")
         self.assertEqual(
             response["message"],
-            self.msg_store.confirm_put_all_goods_in_delivery_package(
-                self.delivery_packaging
-            ),
+            self.msg_store.confirm_put_all_goods_in_delivery_package(self.package_type),
         )
         self.assertTrue(response["data"]["select_line"]["need_confirm_pack_all"])
         response = self.service.dispatch(
             "scan_line",
             params={
                 "picking_id": picking.id,
-                "barcode": self.delivery_packaging.barcode,
-                "confirm_pack_all": self.delivery_packaging.barcode,
+                "barcode": self.package_type.barcode,
+                "confirm_pack_all": self.package_type.barcode,
             },
         )
         # move to summary as all lines are done

--- a/shopfloor/tests/test_checkout_scan_line_no_prefill_qty.py
+++ b/shopfloor/tests/test_checkout_scan_line_no_prefill_qty.py
@@ -20,7 +20,7 @@ class CheckoutScanLineNoPrefillQtyCase(CheckoutScanLineCaseBase):
             cls._fill_stock_for_moves(move, in_lot=True)
         cls.picking.action_assign()
         cls.move_lines = cls.picking.move_line_ids
-        cls.delivery_packaging = (
+        cls.package_type = (
             cls.env["stock.package.type"]
             .sudo()
             .create(
@@ -106,7 +106,7 @@ class CheckoutScanLineNoPrefillQtyCase(CheckoutScanLineCaseBase):
             "scan_line",
             params={
                 "picking_id": self.picking.id,
-                "barcode": self.delivery_packaging.barcode,
+                "barcode": self.package_type.barcode,
             },
         )
         # Back to select_line asking to set some quantities
@@ -132,7 +132,7 @@ class CheckoutScanLineNoPrefillQtyCase(CheckoutScanLineCaseBase):
             "scan_line",
             params={
                 "picking_id": self.picking.id,
-                "barcode": self.delivery_packaging.barcode,
+                "barcode": self.package_type.barcode,
             },
         )
         # Check the line has been packed

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -232,7 +232,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         picking.action_assign()
 
         package = self.env["stock.quant.package"].create(
-            {"package_type_id": self.delivery_packaging.id}
+            {"package_type_id": self.package_type.id}
         )
 
         # assume that product d was already put in a package,
@@ -410,7 +410,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
             self._assert_selected_response(
                 response,
                 selected_lines,
-                message=self.msg_store.packaging_invalid_for_carrier(
+                message=self.msg_store.package_type_invalid_for_carrier(
                     packaging, picking.carrier_id
                 ),
             )

--- a/shopfloor/tests/test_location_content_transfer_putaway.py
+++ b/shopfloor/tests/test_location_content_transfer_putaway.py
@@ -12,7 +12,7 @@ class TestLocationContentTransferPutaway(LocationContentTransferCommonCase):
     @classmethod
     def setUpClassVars(cls, *args, **kwargs):
         super().setUpClassVars(*args, **kwargs)
-        cls.pallets_storage_type = cls.env.ref(
+        cls.pallets_package_type = cls.env.ref(
             "stock_storage_type.package_storage_type_pallets"
         )
         cls.main_pallets_location = cls.env.ref(
@@ -33,14 +33,14 @@ class TestLocationContentTransferPutaway(LocationContentTransferCommonCase):
             {
                 # this will parameterize the putaway to use pallet locations,
                 # and if not, it will stay on the picking type's default dest.
-                "package_type_id": cls.pallets_storage_type.id,
+                "package_type_id": cls.pallets_package_type.id,
             }
         )
         cls.package2 = cls.env["stock.quant.package"].create(
             {
                 # this will parameterize the putaway to use pallet locations,
                 # and if not, it will stay on the picking type's default dest.
-                "package_type_id": cls.pallets_storage_type.id,
+                "package_type_id": cls.pallets_package_type.id,
             }
         )
         # create a location to be sure it's empty
@@ -87,7 +87,7 @@ class TestLocationContentTransferPutaway(LocationContentTransferCommonCase):
         """
         for location in self.all_pallets_locations:
             package = self.env["stock.quant.package"].create(
-                {"package_type_id": self.pallets_storage_type.id}
+                {"package_type_id": self.pallets_package_type.id}
             )
             self._update_qty_in_location(location, self.product_a, 10, package=package)
 

--- a/shopfloor/tests/test_single_pack_transfer_putaway.py
+++ b/shopfloor/tests/test_single_pack_transfer_putaway.py
@@ -10,7 +10,7 @@ class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
     @classmethod
     def setUpClassVars(cls, *args, **kwargs):
         super().setUpClassVars(*args, **kwargs)
-        cls.pallets_storage_type = cls.env.ref(
+        cls.pallets_package_type = cls.env.ref(
             "stock_storage_type.package_storage_type_pallets"
         )
         cls.main_pallets_location = cls.env.ref(
@@ -31,7 +31,7 @@ class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
             {
                 # this will parameterize the putaway to use pallet locations,
                 # and if not, it will stay on the picking type's default dest.
-                "package_type_id": cls.pallets_storage_type.id,
+                "package_type_id": cls.pallets_package_type.id,
             }
         )
         cls._update_qty_in_location(cls.shelf1, cls.product_a, 10, package=cls.package)
@@ -60,7 +60,7 @@ class TestSinglePackTransferPutaway(SinglePackTransferCommonBase):
         """
         for location in self.all_pallets_locations:
             package = self.env["stock.quant.package"].create(
-                {"package_type_id": self.pallets_storage_type.id}
+                {"package_type_id": self.pallets_package_type.id}
             )
             self._update_qty_in_location(location, self.product_a, 10, package=package)
 

--- a/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
+++ b/shopfloor/tests/test_zone_picking_set_line_destination_pick_pack.py
@@ -43,7 +43,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
         super().setUpClassBaseData(*args, **kwargs)
         cls._load_test_models()
         cls.carrier = cls.env["delivery.carrier"].search([], limit=1)
-        delivery_packaging_type = (
+        package_type_type = (
             cls.env["stock.package.type"]
             .sudo()
             .create({"name": "TEST DEFAULT", "package_carrier_type": "test"})
@@ -52,7 +52,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
             {
                 "delivery_type": "test",
                 "integration_level": "rate",  # avoid sending emails
-                "test_default_packaging_id": delivery_packaging_type.id,
+                "test_default_package_type_id": package_type_type.id,
             }
         )
 
@@ -113,7 +113,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
         delivery_pkg = move_line.result_package_id
         self.assertNotIn(delivery_pkg, existing_packages)
         self.assertEqual(
-            delivery_pkg.package_type_id, self.carrier.test_default_packaging_id
+            delivery_pkg.package_type_id, self.carrier.test_default_package_type_id
         )
         message = self.msg_store.confirm_pack_moved()
         message["body"] += "\n" + self.msg_store.goods_packed_in(delivery_pkg)["body"]
@@ -176,7 +176,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
             zone_location,
             picking_type,
             move_line,
-            message=self.service.msg_store.packaging_invalid_for_carrier(
+            message=self.service.msg_store.package_type_invalid_for_carrier(
                 self.free_package.product_packaging_id, self.carrier
             ),
             qty_done=quantity_reserved,
@@ -197,7 +197,7 @@ class ZonePickingSetLineDestinationPickPackCase(ZonePickingCommonCase):
             .create(
                 {
                     "name": "TEST DEFAULT",
-                    "package_type_id": self.carrier.test_default_packaging_id.id,
+                    "package_type_id": self.carrier.test_default_package_type_id.id,
                     "product_id": self.free_product.id,
                 }
             )

--- a/shopfloor_dangerous_goods/actions/schema.py
+++ b/shopfloor_dangerous_goods/actions/schema.py
@@ -6,9 +6,9 @@ from odoo.addons.component.core import Component
 class ShopfloorSchemaAction(Component):
     _inherit = "shopfloor.schema.action"
 
-    def move_line(self, with_packaging=False, with_picking=False):
+    def move_line(self, with_package_type=False, with_picking=False):
         res = super().move_line(
-            with_packaging=with_packaging, with_picking=with_picking
+            with_package_type=with_package_type, with_picking=with_picking
         )
         res["has_lq_products"] = {
             "type": "boolean",
@@ -17,8 +17,8 @@ class ShopfloorSchemaAction(Component):
         }
         return res
 
-    def package(self, with_packaging=False):
-        res = super().package(with_packaging=with_packaging)
+    def package(self, with_package_type=False):
+        res = super().package(with_package_type=with_package_type)
         res["has_lq_products"] = {
             "type": "boolean",
             "nullable": False,

--- a/shopfloor_dangerous_goods/tests/test_actions_data.py
+++ b/shopfloor_dangerous_goods/tests/test_actions_data.py
@@ -52,15 +52,13 @@ class ActionsDataBase(ActionsDataCaseBase):
 
     def test_data_package(self):
         package = self.move_a.move_line_ids.package_id
-        package.product_packaging_id = self.packaging.id
         package.package_type_id = self.storage_type_pallet
-        data = self.data.package(package, picking=self.picking, with_packaging=True)
-        self.assert_schema(self.schema.package(with_packaging=True), data)
+        data = self.data.package(package, picking=self.picking, with_package_type=True)
+        self.assert_schema(self.schema.package(with_package_type=True), data)
         expected = {
             "id": package.id,
             "name": package.name,
-            "packaging": self._expected_packaging(package.product_packaging_id),
-            "storage_type": self._expected_storage_type(package.package_type_id),
+            "storage_type": self._expected_package_type(package.package_type_id),
             "weight": 20.0,
             "has_lq_products": True,
         }

--- a/shopfloor_dangerous_goods/tests/test_actions_data.py
+++ b/shopfloor_dangerous_goods/tests/test_actions_data.py
@@ -52,13 +52,13 @@ class ActionsDataBase(ActionsDataCaseBase):
 
     def test_data_package(self):
         package = self.move_a.move_line_ids.package_id
-        package.package_type_id = self.storage_type_pallet
+        package.package_type_id = self.package_type_pallet
         data = self.data.package(package, picking=self.picking, with_package_type=True)
         self.assert_schema(self.schema.package(with_package_type=True), data)
         expected = {
             "id": package.id,
             "name": package.name,
-            "storage_type": self._expected_package_type(package.package_type_id),
+            "package_type": self._expected_package_type(package.package_type_id),
             "weight": 20.0,
             "has_lq_products": True,
         }

--- a/shopfloor_dangerous_goods_mobile/static/wms/src/js/demo/demo.checkout.esm.js
+++ b/shopfloor_dangerous_goods_mobile/static/wms/src/js/demo/demo.checkout.esm.js
@@ -222,10 +222,10 @@ const DEMO_CHECKOUT_DG = {
             body: "Done",
         },
     },
-    list_packaging: {
-        next_state: "change_packaging",
+    change_list_package_type: {
+        next_state: "change_package_type",
         data: {
-            change_packaging: {
+            change_package_type: {
                 picking: select_pack_picking,
                 package: demotools.makePack(),
                 packaging: _.sampleSize(

--- a/shopfloor_mobile/static/wms/src/components/detail/detail_package.esm.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_package.esm.js
@@ -13,7 +13,7 @@ Vue.component("detail-package", {
             return [
                 {path: "location.name", label: "Location"},
                 {path: "weight", label: "Weight (kg)"},
-                {path: "storage_type.name", label: "Package type"},
+                {path: "package_type.name", label: "Package type"},
             ];
         },
         product_list_options() {

--- a/shopfloor_mobile/static/wms/src/components/detail/detail_package.esm.js
+++ b/shopfloor_mobile/static/wms/src/components/detail/detail_package.esm.js
@@ -13,9 +13,7 @@ Vue.component("detail-package", {
             return [
                 {path: "location.name", label: "Location"},
                 {path: "weight", label: "Weight (kg)"},
-                {path: "packaging.name", label: "Packaging"},
-                {path: "storage_type.name", label: "Storage type"},
-                {path: "package_type.name", label: "Package type"},
+                {path: "storage_type.name", label: "Package type"},
             ];
         },
         product_list_options() {

--- a/shopfloor_mobile/static/wms/src/demo/demo.checkout.esm.js
+++ b/shopfloor_mobile/static/wms/src/demo/demo.checkout.esm.js
@@ -197,10 +197,10 @@ const DEMO_CHECKOUT = {
             body: "Done",
         },
     },
-    list_packaging: {
-        next_state: "change_packaging",
+    change_list_package_type: {
+        next_state: "change_package_type",
         data: {
-            change_packaging: {
+            change_package_type: {
                 picking: select_pack_picking,
                 package: demotools.makePack(),
                 packaging: _.sampleSize(
@@ -219,7 +219,7 @@ const DEMO_CHECKOUT = {
             },
         },
     },
-    set_packaging: {
+    set_package_type: {
         next_state: "summary",
         data: {
             summary: {picking: summary_picking},

--- a/shopfloor_mobile/static/wms/src/scenario/checkout.esm.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.esm.js
@@ -119,7 +119,7 @@ const Checkout = {
                     </v-row>
                 </div>
             </div>
-            <div v-if="state_is('select_delivery_packaging')">
+            <div v-if="state_is('select_package_type')">
                 <item-detail-card
                     v-if="current_doc().record.carrier"
                     :key="make_state_component_key(['picking-carrier', current_doc().record.id])"
@@ -127,8 +127,8 @@ const Checkout = {
                     :options="{main: true, key_title: 'name', title_icon: 'mdi-truck-outline'}"
                     />
                 <manual-select
-                    :records="state.data.packaging"
-                    :options="select_delivery_packaging_manual_select_options()"
+                    :records="state.data.package_type"
+                    :options="select_package_type_manual_select_options()"
                     :key="make_state_component_key(['checkout', 'select-delivery-packaging'])"
                     />
                 <div class="button-list button-vertical-list full">
@@ -184,7 +184,7 @@ const Checkout = {
                     </v-row>
                 </div>
             </div>
-            <div v-if="state_is('change_packaging')">
+            <div v-if="state_is('change_package_type')">
                 <detail-picking-select
                     :record="state.data.picking"
                     :select_records="state.data.packaging"
@@ -344,7 +344,7 @@ const Checkout = {
             };
             return key + "." + possible_paths[key];
         },
-        select_delivery_packaging_manual_select_options: function () {
+        select_package_type_manual_select_options: function () {
             return {
                 showActions: false,
             };

--- a/shopfloor_mobile/static/wms/src/scenario/checkout_states.esm.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout_states.esm.js
@@ -181,7 +181,7 @@ export const checkout_states = function ($instance) {
             },
             on_new_pack: () => {
                 $instance.wait_call(
-                    $instance.odoo.call("list_delivery_packaging", {
+                    $instance.odoo.call("list_package_type", {
                         picking_id: $instance.state.data.picking.id,
                         selected_line_ids: $instance.selectable_line_ids(),
                     })
@@ -208,7 +208,7 @@ export const checkout_states = function ($instance) {
                 $instance.reset_notification();
             },
         },
-        select_delivery_packaging: {
+        select_package_type: {
             display_info: {
                 title: "Select delivery packaging",
                 scan_placeholder: "Scan package type",
@@ -309,7 +309,7 @@ export const checkout_states = function ($instance) {
             },
             on_pkg_change_type: (pkg) => {
                 $instance.wait_call(
-                    $instance.odoo.call("list_packaging", {
+                    $instance.odoo.call("change_list_package_type", {
                         picking_id: $instance.state.data.picking.id,
                         package_id: pkg.id,
                     })
@@ -340,9 +340,9 @@ export const checkout_states = function ($instance) {
                 );
             },
         },
-        change_packaging: {
+        change_package_type: {
             display_info: {
-                title: "Change packaging",
+                title: "Change package type",
             },
             events: {
                 select: "on_select",
@@ -352,7 +352,7 @@ export const checkout_states = function ($instance) {
                     return;
                 }
                 $instance.wait_call(
-                    $instance.odoo.call("set_packaging", {
+                    $instance.odoo.call("change_set_package_type", {
                         picking_id: $instance.state.data.picking.id,
                         package_id: $instance.state.data.package.id,
                         package_type_id: selected.id,

--- a/shopfloor_mobile/static/wms/src/wms_utils.esm.js
+++ b/shopfloor_mobile/static/wms/src/wms_utils.esm.js
@@ -167,7 +167,7 @@ export class WMSUtils {
 
     group_by_package_type(lines) {
         const res = [];
-        const grouped = _.groupBy(lines, "package_dest.packaging.name");
+        const grouped = _.groupBy(lines, "package_dest.storage_type.name");
         _.forEach(grouped, function (products, packaging_name) {
             res.push({
                 _is_group: true,

--- a/shopfloor_mobile/static/wms/src/wms_utils.esm.js
+++ b/shopfloor_mobile/static/wms/src/wms_utils.esm.js
@@ -167,7 +167,7 @@ export class WMSUtils {
 
     group_by_package_type(lines) {
         const res = [];
-        const grouped = _.groupBy(lines, "package_dest.storage_type.name");
+        const grouped = _.groupBy(lines, "package_dest.package_type.name");
         _.forEach(grouped, function (products, packaging_name) {
             res.push({
                 _is_group: true,

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -853,7 +853,7 @@ class Reception(Component):
         packages_data = self.data.packages(
             packages.with_context(picking_id=picking.id).sorted(),
             picking=picking,
-            with_packaging=True,
+            with_package_type=True,
         )
         return self._response(
             next_state="select_dest_package",
@@ -1754,7 +1754,7 @@ class ShopfloorReceptionValidatorResponse(Component):
                 "type": "list",
                 "schema": {
                     "type": "dict",
-                    "schema": self.schemas.package(with_packaging=True),
+                    "schema": self.schemas.package(with_package_type=True),
                 },
             },
             "picking": {"type": "dict", "schema": self.schemas.picking()},

--- a/shopfloor_reception/tests/common.py
+++ b/shopfloor_reception/tests/common.py
@@ -114,7 +114,7 @@ class CommonCase(BaseCommonCase):
         return self.data.move_line(move_line)
 
     def _package_data(self, package, picking):
-        return self.data.package(package, picking=picking, with_packaging=True)
+        return self.data.package(package, picking=picking, with_package_type=True)
 
     def _packaging_data(self, packaging):
         return self.data.packaging(packaging)

--- a/shopfloor_reception/tests/test_select_dest_package.py
+++ b/shopfloor_reception/tests/test_select_dest_package.py
@@ -88,7 +88,7 @@ class TestSelectDestPackage(CommonCase):
         package_data = self.data.packages(
             self.package.with_context(picking_id=picking.id),
             picking=picking,
-            with_packaging=True,
+            with_package_type=True,
         )
         self.assert_response(
             response,

--- a/shopfloor_reception/tests/test_set_quantity_action.py
+++ b/shopfloor_reception/tests/test_set_quantity_action.py
@@ -28,7 +28,7 @@ class TestSetQuantityAction(CommonCase):
         package_data = self.data.packages(
             package.with_context(picking_id=self.picking.id),
             picking=self.picking,
-            with_packaging=True,
+            with_package_type=True,
         )
         self.assert_response(
             response,

--- a/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
@@ -453,7 +453,7 @@ const Reception = {
                             label: "Lines already in pack",
                             display_no_value: true,
                         },
-                        {path: "storage_type.name", label: "Package type"},
+                        {path: "package_type.name", label: "Package type"},
                     ],
                 },
             };


### PR DESCRIPTION
* Delivery package (product packaging) is replaced by package type (stock.package.type)
* Having in shopfloor the packaging of the package is misleading, it serves only for setting default dimensions at reception. I removed it to prevent mistakes
* storage type renamed to package type

cc @mmequignon @TDu @simahawk 