### PR TITLE
[18.0][FIX] shopfloor: Export packaging weight

### DIFF
--- a/shopfloor/actions/data_detail.py
+++ b/shopfloor/actions/data_detail.py
@@ -237,7 +237,7 @@ class DataDetailAction(Component):
             "packaging_length:length",
             "width",
             "height",
-            ("max_weight", lambda rec, fname: rec.package_type_id.max_weight),
+            "weight",
             "length_uom_name:length_uom",
             "weight_uom_name:weight_uom",
             "barcode:barcode",

--- a/shopfloor/actions/schema_detail.py
+++ b/shopfloor/actions/schema_detail.py
@@ -132,7 +132,7 @@ class ShopfloorSchemaDetailAction(Component):
                 "length": {"type": "float", "nullable": True, "required": False},
                 "width": {"type": "float", "nullable": True, "required": False},
                 "height": {"type": "float", "nullable": True, "required": False},
-                "max_weight": {"type": "float", "nullable": True, "required": False},
+                "weight": {"type": "float", "nullable": True, "required": False},
                 "length_uom": {"type": "string", "nullable": True, "required": False},
                 "weight_uom": {"type": "string", "nullable": True, "required": False},
                 "barcode": {"type": "string", "nullable": True, "required": False},

--- a/shopfloor/tests/test_actions_data_base.py
+++ b/shopfloor/tests/test_actions_data_base.py
@@ -289,7 +289,7 @@ class ActionsDataDetailCaseBase(ActionsDataCaseBase):
                 "length": record.packaging_length,
                 "width": record.width,
                 "height": record.height,
-                "max_weight": record.package_type_id.max_weight,
+                "weight": record.weight,
                 "length_uom": record.length_uom_name,
                 "weight_uom": record.weight_uom_name,
                 "barcode": record.barcode,


### PR DESCRIPTION
Wrong weight was exported.
Export packaging.weight instead of package_type.max_weight