### PR TITLE
[18.0][FIX] shopfloor_reception: Fix set_destination next screen

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1305,24 +1305,25 @@ class Reception(Component):
         # In such case, we must ensure there's another move with the remaining
         # quantity to do, so selected_line is extracted in a new move as expected.
 
-        # Always keep the quantity todo at zero, the same is done
-        # in Odoo when move lines are created manually (setting)
         lines_with_qty_todo = selected_line.move_id.move_line_ids.filtered(
             lambda line: line.state not in ("cancel", "done") and line.quantity > 0
         )
 
         move = selected_line.move_id
-        lock = self._actions_for("lock")
-        lock.for_update(move)
-        if lines_with_qty_todo:
-            lines_with_qty_todo.quantity = 0
-
         move_quantity = move.product_uom._compute_quantity(
             move.product_uom_qty, selected_line.product_uom_id
         )
         if selected_line.qty_picked == move_quantity:
             # In case of full quantity, post the initial move
             return selected_line.move_id.extract_and_action_done()
+
+        # Always keep the quantity todo at zero, the same is done
+        # in Odoo when move lines are created manually (setting)
+        lock = self._actions_for("lock")
+        lock.for_update(move)
+        if lines_with_qty_todo:
+            lines_with_qty_todo.quantity = 0
+
         split_move_vals = move._split(selected_line.qty_picked)
         new_move = move.create(split_move_vals)
         new_move.move_line_ids = selected_line
@@ -1404,6 +1405,12 @@ class Reception(Component):
         response = self._post_line(selected_line)
         if response:
             return response
+        # After line is posted, if picking is done,
+        # return select document with success message
+        if picking.state == "done":
+            message = self.msg_store.transfer_done_success(picking)
+            return self._response_for_select_document(message=message)
+        # Else return select move
         return self._response_for_select_move(picking)
 
     def select_dest_package(

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -107,9 +107,10 @@ class TestSetDestination(CommonCase):
             message={"message_type": "error", "body": "You cannot place it here"},
         )
 
-    def test_auto_posting(self):
+    def test_auto_posting_partial(self):
         self.menu.sudo().auto_post_line = True
-        picking = self._create_picking()
+        # Creating a picking with a single move, with qty todo = 10
+        picking = self._create_picking(lines=[(self.product_a, 10)])
         selected_move_line = picking.move_line_ids.filtered(
             lambda li: li.product_id == self.product_a
         )
@@ -129,13 +130,17 @@ class TestSetDestination(CommonCase):
         # and dest package & dest location are set,
         # a line with 3 demand will be automatically extracted
         # in a new picking, which will be marked as done.
-        self.service.dispatch(
+        response = self.service.dispatch(
             "set_destination",
             params={
                 "picking_id": picking.id,
                 "selected_line_id": selected_move_line.id,
                 "location_name": self.dispatch_location.name,
             },
+        )
+        # Next screen is select move, because picking is not done
+        self.assert_response(
+            response, next_state="select_move", data=self._data_for_select_move(picking)
         )
         # The line has been moved to a different picking.
         self.assertNotEqual(picking, selected_move_line.picking_id)
@@ -151,6 +156,74 @@ class TestSetDestination(CommonCase):
         self.assertEqual(line_in_picking.quantity, 7)
         self.assertEqual(line_in_picking.qty_picked, 0)
         self.assertEqual(picking.state, "assigned")
+
+    def test_auto_posting_full_one_line(self):
+        self.menu.sudo().auto_post_line = True
+        # Create a picking with a single move with qty todo = 10
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda li: li.product_id == self.product_a
+        )
+        # User has previously scanned the full qty
+        # A new pack has been created and assigned to the line.
+        self.service.dispatch(
+            "process_with_new_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                "quantity": 10,
+            },
+        )
+        # Full qty processed, picking is done, and next screen is select document.
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                "location_name": self.dispatch_location.name,
+            },
+        )
+        message = self.msg_store.transfer_done_success(picking)
+        self.assert_response(
+            response, next_state="select_document", data=self.ANY, message=message
+        )
+
+    def test_auto_posting_full_two_lines(self):
+        self.menu.sudo().auto_post_line = True
+        # Create a picking with a two moves with qty todo = 10
+        picking = self._create_picking()
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda li: li.product_id == self.product_a
+        )
+        # User has previously scanned the full qty
+        # A new pack has been created and assigned to the line.
+        self.service.dispatch(
+            "process_with_new_pack",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                "quantity": 10,
+            },
+        )
+        # Full qty processed, but one more line to process,
+        # next screen is select_move
+        response = self.service.dispatch(
+            "set_destination",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                "location_name": self.dispatch_location.name,
+            },
+        )
+        self.assert_response(
+            response, next_state="select_move", data=self._data_for_select_move(picking)
+        )
+        # Lines has been moved in another picking
+        self.assertNotEqual(picking, selected_move_line.picking_id)
+        # Fully processed
+        self.assertEqual(selected_move_line.picking_id.state, "done")
+        # One move remaining in the picking, for product b, still to be processed
+        self.assertEqual(picking.move_ids.product_id, self.product_b)
 
     def test_auto_posting_concurent_work(self):
         """Check 2 users working on the same move.


### PR DESCRIPTION
Depending on the qty processed and the enabled options, selecting the destination might redirect to select move, select picking, etc...

This pull request fixes this behavior, and add tests that were missing.

ping @jbaudoux 