### PR TITLE
[18.0][FIX] shopfloor_reception: drop useless action assign

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -56,15 +56,20 @@ class StockMove(models.Model):
                 == 0
             ):
                 return self.browse()
-            split_move_vals = self._split(qty_to_split)
-            split_move = self.create(split_move_vals)
-            split_move.move_line_ids = to_move
-            split_move._action_confirm(merge=False)
-            split_move._recompute_state()
-            if split_move.state != "assigned":
-                split_move._action_assign()
+            new_move_vals_list = self._split(qty_to_split)
+            confirm_dict = dict(
+                state=self.state,
+                reservation_date=self.reservation_date,
+            )
+            [d.update(confirm_dict) for d in new_move_vals_list]
+            # Only create the move, do not call _action_confirm as
+            # since Odoo 15.0, it calls _action_assign() or we only
+            # want to split
+            new_move = self.env["stock.move"].create(new_move_vals_list)
+            new_move.move_line_ids = to_move
+            new_move._recompute_state()
             self._recompute_state()
-            return split_move
+            return new_move
         return self.browse()
 
     def split_unavailable_qty(self):

--- a/shopfloor/models/stock_picking.py
+++ b/shopfloor/models/stock_picking.py
@@ -1,6 +1,6 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class StockPicking(models.Model):
@@ -70,56 +70,6 @@ class StockPicking(models.Model):
         ):
             return False
         return super()._check_move_lines_map_quant_package(package)
-
-    def split_assigned_move_lines(self, move_lines=None):
-        """Put all reserved quantities (move lines) in their own moves and transfer.
-
-        As a result, the current transfer will contain only confirmed moves.
-        """
-        self.ensure_one()
-        # Check in the picking all the moves which are partially available or confirmed
-        moves = self.move_lines.filtered(
-            lambda m: m.state in ("partially_available", "confirmed")
-        )
-        # If one of these moves has an ancestor, split the moves
-        # then extract all the assigned moves in a new transfer.
-        # Indeed, a move without ancestor won't see its reserved qty changed
-        # automatically over time.
-        has_ancestors = bool(
-            moves.move_orig_ids.filtered(lambda m: m.state not in ("cancel", "done"))
-        )
-        if not has_ancestors:
-            return self.id
-        # Get only transfers composed of moves assigned or confirmed
-        moves.split_other_move_lines(moves.move_line_ids)
-        # Put assigned moves related to processed move lines into a separate transfer
-        if move_lines:
-            assigned_moves = self.move_lines & move_lines.move_id
-        else:
-            assigned_moves = self.move_lines.filtered(lambda m: m.state == "assigned")
-        if assigned_moves == self.move_lines:
-            return self.id
-        new_picking = self.copy(
-            {
-                "name": "/",
-                "move_lines": [],
-                "move_line_ids": [],
-                "backorder_id": self.id,
-            }
-        )
-        message = _(
-            'The backorder <a href="#" '
-            'data-oe-model="stock.picking" '
-            'data-oe-id="%(new_picking_id)d">%(new_picking_name)s</a> has been created.'
-        ) % dict(new_picking_id=new_picking.id, new_picking_name=new_picking.name)
-        self.message_post(body=message)
-        assigned_moves.write({"picking_id": new_picking.id})
-        assigned_moves.mapped("move_line_ids").write({"picking_id": new_picking.id})
-        assigned_moves.move_line_ids.package_level_id.write(
-            {"picking_id": new_picking.id}
-        )
-        assigned_moves._action_assign()
-        return new_picking.id
 
     def _put_in_pack(self, move_line_ids):
         # Marks the corresponding move lines as 'shopfloor_checkout_done'

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1451,10 +1451,6 @@ class Reception(Component):
         # In such case, we must ensure there's another move with the remaining
         # quantity to do, so selected_line is extracted in a new move as expected.
 
-        lines_with_qty_todo = selected_line.move_id.move_line_ids.filtered(
-            lambda line: line.state not in ("cancel", "done") and line.quantity > 0
-        )
-
         move = selected_line.move_id
         move_quantity = move.product_uom._compute_quantity(
             move.product_uom_qty, selected_line.product_uom_id
@@ -1467,16 +1463,15 @@ class Reception(Component):
         # in Odoo when move lines are created manually (setting)
         lock = self._actions_for("lock")
         lock.for_update(move)
+        lines_with_qty_todo = selected_line.move_id.move_line_ids.filtered(
+            lambda line: line.state not in ("cancel", "done")
+            and line.quantity > 0
+            and line != selected_line
+        )
         if lines_with_qty_todo:
             lines_with_qty_todo.quantity = 0
-
-        split_move_vals = move._split(selected_line.qty_picked)
-        new_move = move.create(split_move_vals)
-        new_move.move_line_ids = selected_line
-        new_move._action_confirm(merge=False)
         selected_line.quantity = selected_line.qty_picked
-        new_move._recompute_state()
-        new_move._action_assign()
+        new_move = move.split_other_move_lines(selected_line, intersection=True)
         # Set back the quantity to do on one of the lines
         line = fields.first(
             move.move_line_ids.filtered(

--- a/shopfloor_reception/tests/test_set_destination.py
+++ b/shopfloor_reception/tests/test_set_destination.py
@@ -150,6 +150,8 @@ class TestSetDestination(CommonCase):
         self.assertNotEqual(picking, selected_move_line.picking_id)
         # Its quantity_picked is 3.
         self.assertEqual(selected_move_line.qty_picked, 3)
+        # The destination location is dispatch_location
+        self.assertEqual(selected_move_line.location_dest_id, self.dispatch_location)
         # The new picking is marked as done.
         self.assertEqual(selected_move_line.picking_id.state, "done")
 


### PR DESCRIPTION
odoo is now calling the recomputation of putaway inside action assign. It cannot be called blindly anymore. I removed it from method that have no reason to make this call.

cc  @TDu 