### PR TITLE
[18.0][IMP] shopfloor_mobile: display the current picking note if any

### DIFF
--- a/shopfloor_mobile/static/wms/src/scenario/checkout.esm.js
+++ b/shopfloor_mobile/static/wms/src/scenario/checkout.esm.js
@@ -80,6 +80,12 @@ const Checkout = {
                 <v-alert type="info" tile v-if="state.data.packing_info" class="packing-info">
                     <p v-text="state.data.packing_info" />
                 </v-alert>
+                <v-alert type="info" tile
+                    v-if="(state.data.picking.note && state.data.picking.note !== '<p></p>')"
+                    class="packing-info"
+                    >
+                    <p class="split-text-lines" v-html="state.data.picking.note" />
+                </v-alert>
                 <item-detail-card
                     v-if="state.data.picking.carrier"
                     :key="make_state_component_key(['picking-carrier', state.data.picking.id])"

--- a/shopfloor_mobile/static/wms/src/scenario/cluster_picking.esm.js
+++ b/shopfloor_mobile/static/wms/src/scenario/cluster_picking.esm.js
@@ -35,6 +35,12 @@ const ClusterPicking = {
                 v-on:confirm="state.on_confirm"
                 v-on:cancel="state.on_cancel"
                 />
+            <v-alert type="info" tile
+                v-if="state_is('start_line') && (state.data.picking.note && state.data.picking.note !== '<p></p>')"
+                class="packing-info"
+                >
+                <p class="split-text-lines" v-html="state.data.picking.note" />
+            </v-alert>
             <batch-picking-line-detail
                 v-if="state_in(['start_line', 'scan_destination', 'change_pack_lot', 'stock_issue'])"
                 :line="state.data"


### PR DESCRIPTION
In v14 there is the never merged PR:

* https://github.com/OCA/wms/pull/839

Here only the changes in the js are needed and migrated.

If a note is set on the picking being processed it will be displayed on: the cluster picking scenario when starting to work on a line. The checkout scenario when selecting the packaging.