### PR TITLE
[18.0][FIX] shopfloor (single_pack_transfer): check that package level is assigned

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 import logging
 
-from odoo import _
+from odoo import _, fields
 
 from odoo.addons.component.core import Component
 
@@ -150,6 +150,31 @@ class MessageAction(Component):
                 "operation type %(picking_type_name)s.",
                 package_name=package.name,
                 picking_type_name=picking_type.name,
+            ),
+        }
+
+    def package_level_not_assigned(self, package_level):
+        package = package_level.package_id
+        body = "Package %(package)s cannot be reserved in %(location)s%(extra)s."
+        extra = ""
+        # Check if quant has an expiration_date outdated.
+        # Starting from Odoo 17.0+, `product_expiry` is blocking the reservation if:
+        #   - product is configured with 'use_expiration_date = True'
+        #   - quant.expiration_date < move.date
+        move = fields.first(package_level.move_ids)
+        if move.product_id.use_expiration_date and any(
+            quant.expiration_date < move.date
+            for quant in package.quant_ids
+            if quant.expiration_date
+        ):
+            extra = " (date has expired?)"
+        return {
+            "message_type": "error",
+            "body": _(
+                body,
+                package=package.name,
+                location=package.location_id.name,
+                extra=extra,
             ),
         }
 

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -141,6 +141,10 @@ class SinglePackTransfer(Component):
         message = self.msg_store.no_pending_operation_for_pack(package)
         if not package_level and self.is_allow_move_create():
             package_level = self._create_package_level(package)
+            if package_level.state != "assigned":
+                message = self.msg_store.package_level_not_assigned(package_level)
+                savepoint.rollback()
+                return self._response_for_start(message=message)
             if not self.is_dest_location_valid(
                 package_level.move_line_ids.move_id, package_level.location_dest_id
             ):

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -2,6 +2,7 @@
 # Copyright 2020 Akretion (http://www.akretion.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import fields
 from odoo.tests import Form
 
 from .test_single_pack_transfer_base import SinglePackTransferCommonBase
@@ -205,6 +206,45 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         }
 
         self.assert_response(response, next_state="scan_location", data=expected_data)
+
+    def test_start_no_operation_expired_date(self):
+        """Test /start when the pack to move is expired.
+
+        The pre-conditions:
+
+        * The option "Allow Move Creation" is turned on on the menu
+        * A Pack exists in Stock/Shelf1.
+        * No stock picking exists to move the Pack from Stock/Shelf1 to
+          Stock/Shelf2, or the state is not assigned.
+        * Packed product is configured to use expiration date
+        * Packed product is expired
+
+        Expected result:
+
+        * Return a message
+        """
+        self.menu.sudo().allow_move_create = True
+        barcode = self.pack_a.name
+        params = {"barcode": barcode}
+        self.picking.do_unreserve()
+        self.quant_a.product_id.use_expiration_date = True
+        self.quant_a.expiration_date = fields.Date.from_string("2020-01-01")
+
+        response = self.service.dispatch("start", params=params)
+
+        self.assert_response(
+            response,
+            next_state="start",
+            message={
+                "message_type": "error",
+                "body": self.env._(
+                    "Package %(package)s cannot be reserved in %(location)s%(extra)s.",
+                    package=self.pack_a.name,
+                    location=self.pack_a.location_id.name,
+                    extra=" (date has expired?)",
+                ),
+            },
+        )
 
     def test_start_barcode_not_known(self):
         """Test /start when the barcode is unknown


### PR DESCRIPTION
Reservation could not be done as expected especially since Odoo 17.0 where `product_expiry` [is filtering out the expired quants](https://github.com/odoo/odoo/blob/4d549a5712295f4164c4f725af12474ff99becbf/addons/product_expiry/models/stock_move.py#L75-L83).

This commit checks that package level is well reserved in 'Single Pack Transfer'.

It's important to get the package level assigned, so put-away are computed as expected (and also others modules like `stock_dynamic_routing` are triggered).

NOTE: with this new `product_expiry` logic, it seems impossible to move expired goods to another location (as it's impossible to reserve them). To workaround that, users could update the expiration date of a quant, or unset `use_expiration_date` on the product to move such goods.

Output when scanning an expired package:
<img width="645" height="197" alt="image" src="https://github.com/user-attachments/assets/d9ee8e32-075d-4031-be6d-90fb0fda0ff0" />
