### PR TITLE
[18.0][IMP] shopfloor, location_content_transfer: ignore expiration date when moving goods

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -27,6 +27,8 @@
         #  OCA / stock-logistics-workflow
         "stock_move_line_change_lot",
         "stock_picking_progress",
+        #  OCA / stock-logistics-reservation
+        "product_expiry_assign",
         #  OCA / stock-logistics-tracking
         "stock_quant_package_dimension",
         "stock_quant_package_product_packaging",

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -370,7 +370,12 @@ class LocationContentTransfer(Component):
                 return self._response_for_start(
                     message=self.msg_store.location_empty(location)
                 )
-            new_moves = self._create_moves_from_location(location)
+            new_moves = self._create_moves_from_location(location).with_context(
+                # Skip reservation constraint added by product_expiry
+                # regarding expired quants. In location content transfer we
+                # want to move all goods, whatever their expiration dates are.
+                without_expiration=True
+            )
             if not new_moves:
                 savepoint.rollback()
                 return self._response_for_start(


### PR DESCRIPTION
Depends on:
- https://github.com/OCA/stock-logistics-reservation/pull/33

Question: should we do the same on others scenarios? Or should we propose instead an option on all SF scenarios to bypass such reservation constraint?