### PR TITLE
[18.0][FIX] shopfloor_reception: fix new line creation

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -1258,7 +1258,8 @@ class Reception(Component):
         if compare == -1:
             default_values = {
                 "lot_id": False,
-                "shopfloor_user_id": self.env.uid,
+                # The leftover to be picked later should not be assigned to any users
+                "shopfloor_user_id": False,
                 "expiration_date": False,
             }
             line._split_qty_to_be_done(quantity, **default_values)


### PR DESCRIPTION
When a new line is created for the left over quantity that needs to be picked, it should not be assigned to any user. Because we don't know at that moment who will work on it.