### PR TITLE
[18.0][IMP] shopfloor_reception: imp manual_select_move

### DIFF
--- a/shopfloor/tests/test_location_content_transfer_single.py
+++ b/shopfloor/tests/test_location_content_transfer_single.py
@@ -543,6 +543,13 @@ class LocationContentTransferSingleCase(LocationContentTransferCommonCase):
             - Only the first quantity should be transfered
             - The backorder line should be proposed after
         """
+        # Making sure that no other picking are assigned to the user
+        # Because they could be picked by the start_single at the end of the test
+        # Instead of the backorder
+        pickings = self.env["stock.picking"].search(
+            [("user_id", "=", self.env.uid), ("id", "!=", self.picking3.id)]
+        )
+        pickings.write({"user_id": False})
         move_line = self.picking3.move_line_ids[0]
         previous_priority = move_line.shopfloor_priority
         self.assertFalse(move_line.shopfloor_postponed)

--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -986,6 +986,12 @@ class Reception(Component):
     def manual_select_move(self, move_id):
         move = self.env["stock.move"].browse(move_id)
         picking = move.picking_id
+        message = self._check_move_available(move)
+        if message:
+            return self._response_for_select_move(
+                picking,
+                message=message,
+            )
         return self._scan_line__find_or_create_line(picking, move)
 
     def done_action(self, picking_id, confirmation=False):

--- a/shopfloor_reception/tests/test_select_move.py
+++ b/shopfloor_reception/tests/test_select_move.py
@@ -317,3 +317,27 @@ class TestSelectLine(CommonCase):
                 "selected_move_line": self.data.move_lines(selected_move_line),
             },
         )
+
+    def test_manual_select_move_already_done(self):
+        picking = self._create_picking(lines=[(self.product_b, 10)])
+        selected_move = picking.move_ids.filtered(
+            lambda m: m.product_id == self.product_b
+        )
+        move_line = selected_move.move_line_ids
+        package = self.env["stock.quant.package"].create({"name": "PackateOne"})
+        move_line.result_package_id = package
+        move_line.picked = True
+        move_line._action_done()
+
+        response = self.service.dispatch(
+            "manual_select_move",
+            params={"move_id": selected_move.id},
+        )
+        self.assertEqual(response["next_state"], "select_move")
+        message = "Move already processed."
+        self.assert_response(
+            response,
+            next_state="select_move",
+            data=self._data_for_select_move(picking),
+            message={"message_type": "warning", "body": message},
+        )


### PR DESCRIPTION
When scanning a barcode if the resulting selected move is done, the system shows a warning and comes back to the selection.

This change implementes the same functionality but when selecting a move manually (with the checkbox)