### PR TITLE
[18.0][FWP] shopfloor: Ensure destination location on moves for allow move create

### DIFF
--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -272,14 +272,13 @@ class StockAction(Component):
 
     def _set_destination_on_lines(self, lines, location_dest):
         # when writing the destination on the package level, it writes
-        # on the moves and move lines
+        # on the move lines
         lines_with_package_level = lines.package_level_id.move_line_ids
         lines_without_package_level = lines - lines_with_package_level
         if lines_with_package_level:
             lines_with_package_level.package_level_id.location_dest_id = location_dest
         if lines_without_package_level:
             lines_without_package_level.location_dest_id = location_dest
-            lines_without_package_level.move_id.location_dest_id = location_dest
 
     def unload_package(self, lines):
         lines.result_package_id = False

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -284,6 +284,7 @@ class StockAction(Component):
     def unload_package(self, lines):
         lines.result_package_id = False
 
-    def set_destination_on_lines(self, lines, location_dest):
-        self._lock_lines(lines)
+    def set_destination_on_lines(self, lines, location_dest, lock_lines=True):
+        if lock_lines:
+            self._lock_lines(lines)
         self._set_destination_on_lines(lines, location_dest)

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -1,4 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import _, fields
 from odoo.tools.float_utils import float_compare, float_round
@@ -265,3 +266,26 @@ class StockAction(Component):
         if float_compare(qty_picked, qty_todo, precision_rounding=rounding) > 0:
             return False
         return True
+
+    def _lock_lines(self, lines):
+        self._actions_for("lock").for_update(lines)
+
+    def _set_destination_on_lines(self, lines, location_dest):
+        # when writing the destination on the package level, it writes
+        # on the moves and move lines
+        lines_with_package_level = lines.package_level_id.move_line_ids
+        lines_without_package_level = lines - lines_with_package_level
+        if lines_with_package_level:
+            lines_with_package_level.package_level_id.location_dest_id = location_dest
+        if lines_without_package_level:
+            lines_without_package_level.location_dest_id = location_dest
+            lines_without_package_level.move_id.location_dest_id = location_dest
+
+    def _unload_package(self, lines):
+        lines.result_package_id = False
+
+    def set_destination_and_unload_lines(self, lines, location_dest, unload=False):
+        self._lock_lines(lines)
+        self._set_destination_on_lines(lines, location_dest)
+        if unload:
+            self._unload_package(lines)

--- a/shopfloor/actions/stock.py
+++ b/shopfloor/actions/stock.py
@@ -281,11 +281,9 @@ class StockAction(Component):
             lines_without_package_level.location_dest_id = location_dest
             lines_without_package_level.move_id.location_dest_id = location_dest
 
-    def _unload_package(self, lines):
+    def unload_package(self, lines):
         lines.result_package_id = False
 
-    def set_destination_and_unload_lines(self, lines, location_dest, unload=False):
+    def set_destination_on_lines(self, lines, location_dest):
         self._lock_lines(lines)
         self._set_destination_on_lines(lines, location_dest)
-        if unload:
-            self._unload_package(lines)

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1232,8 +1232,9 @@ class ClusterPicking(Component):
         return self._unload_end(batch, completion_info_popup=completion_info_popup)
 
     def _unload_write_destination_on_lines(self, lines, location):
-        lines.write({"shopfloor_unloaded": True, "location_dest_id": location.id})
-        lines.package_level_id.location_dest_id = location
+        stock = self._actions_for("stock")
+        stock.set_destination_and_unload_lines(lines, location)
+        lines.write({"shopfloor_unloaded": True})
         for picking in lines.batch_id.picking_ids:
             picking_lines = lines.filtered(lambda x, p=picking: x.picking_id == p)
             self._unload_set_picking_to_done(picking, picking_lines)
@@ -1369,15 +1370,11 @@ class ClusterPicking(Component):
             batch, package, lines, barcode, confirmation=confirmation
         )
 
-    def _lock_lines(self, lines):
-        """Lock move lines"""
-        self._actions_for("lock").for_update(lines)
-
     def _unload_scan_destination_lines(
         self, batch, package, lines, barcode, confirmation=None
     ):
         # Lock move lines that will be updated
-        self._lock_lines(lines)
+        self._actions_for("lock").for_update(lines)
         first_line = fields.first(lines)
         scanned_location = self._actions_for("search").location_from_scan(barcode)
         if not scanned_location:

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1233,7 +1233,7 @@ class ClusterPicking(Component):
 
     def _unload_write_destination_on_lines(self, lines, location):
         stock = self._actions_for("stock")
-        stock.set_destination_and_unload_lines(lines, location)
+        stock.set_destination_on_lines(lines, location)
         lines.write({"shopfloor_unloaded": True})
         for picking in lines.batch_id.picking_ids:
             picking_lines = lines.filtered(lambda x, p=picking: x.picking_id == p)

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -427,10 +427,9 @@ class LocationContentTransfer(Component):
         )
         return lines
 
-    # hook used in module shopfloor_checkout_sync
     def _write_destination_on_lines(self, lines, location):
-        lines.location_dest_id = location
-        lines.package_level_id.location_dest_id = location
+        stock = self._actions_for("stock")
+        stock.set_destination_and_unload_lines(lines, location)
 
     def _set_all_destination_lines_and_done(self, pickings, move_lines, dest_location):
         self._write_destination_on_lines(move_lines, dest_location)

--- a/shopfloor/services/location_content_transfer.py
+++ b/shopfloor/services/location_content_transfer.py
@@ -429,7 +429,7 @@ class LocationContentTransfer(Component):
 
     def _write_destination_on_lines(self, lines, location):
         stock = self._actions_for("stock")
-        stock.set_destination_and_unload_lines(lines, location)
+        stock.set_destination_on_lines(lines, location)
 
     def _set_all_destination_lines_and_done(self, pickings, move_lines, dest_location):
         self._write_destination_on_lines(move_lines, dest_location)

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -1,6 +1,7 @@
 # Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
 # Copyright 2020-2021 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2020 Akretion (http://www.akretion.com)
+# Copyright 2025 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from odoo import fields
 
@@ -269,10 +270,10 @@ class SinglePackTransfer(Component):
         return self._response_for_start(message=message, popup=completion_info_popup)
 
     def _set_destination_and_done(self, package_level, scanned_location):
-        # when writing the destination on the package level, it writes
-        # on the move lines
-        package_level.location_dest_id = scanned_location
         stock = self._actions_for("stock")
+        stock.set_destination_and_unload_lines(
+            package_level.move_line_ids, scanned_location
+        )
         stock.put_package_level_in_move(package_level)
         stock.validate_moves(package_level.move_line_ids.move_id)
 

--- a/shopfloor/services/single_pack_transfer.py
+++ b/shopfloor/services/single_pack_transfer.py
@@ -271,9 +271,7 @@ class SinglePackTransfer(Component):
 
     def _set_destination_and_done(self, package_level, scanned_location):
         stock = self._actions_for("stock")
-        stock.set_destination_and_unload_lines(
-            package_level.move_line_ids, scanned_location
-        )
+        stock.set_destination_on_lines(package_level.move_line_ids, scanned_location)
         stock.put_package_level_in_move(package_level)
         stock.validate_moves(package_level.move_line_ids.move_id)
 

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1595,9 +1595,9 @@ class ZonePicking(Component):
 
     def _write_destination_on_lines(self, lines, location):
         stock = self._actions_for("stock")
-        stock.set_destination_and_unload_lines(
-            lines, location, unload=self.work.menu.unload_package_at_destination
-        )
+        stock.set_destination_on_lines(lines, location)
+        if self.work.menu.unload_package_at_destination:
+            stock.unload_package(lines)
 
     def unload_split(self):
         """Indicates that now the buffer must be treated line per line

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1041,7 +1041,7 @@ class ZonePicking(Component):
             )
             return (package_changed, response)
         stock = self._actions_for("stock")
-        self._lock_lines(move_line)
+        stock._lock_lines(move_line)
         try:
             stock.mark_move_line_as_picked(
                 move_line, quantity, package, check_user=True
@@ -1594,11 +1594,10 @@ class ZonePicking(Component):
         return self._set_destination_all_response(buffer_lines, message=message)
 
     def _write_destination_on_lines(self, lines, location):
-        self._lock_lines(lines)
-        lines.location_dest_id = location
-        lines.package_level_id.location_dest_id = location
-        if self.work.menu.unload_package_at_destination:
-            lines.result_package_id = False
+        stock = self._actions_for("stock")
+        stock.set_destination_and_unload_lines(
+            lines, location, unload=self.work.menu.unload_package_at_destination
+        )
 
     def unload_split(self):
         """Indicates that now the buffer must be treated line per line
@@ -1678,10 +1677,6 @@ class ZonePicking(Component):
         return self._unload_response(
             unload_single_message=self.msg_store.barcode_no_match(package.name),
         )
-
-    def _lock_lines(self, lines):
-        """Lock move lines"""
-        self._actions_for("lock").for_update(lines)
 
     def unload_set_destination(self, package_id, barcode, confirmation=None):
         """Scan the final destination for move lines in the buffer with the

--- a/shopfloor/tests/test_single_pack_transfer.py
+++ b/shopfloor/tests/test_single_pack_transfer.py
@@ -192,7 +192,8 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
         package_level = move_line.package_level_id
 
         self.assertTrue(package_level.is_done)
-
+        self.assertEqual(move_line.location_id, self.pack_a.location_id)
+        self.assertEqual(move_line.move_id.location_id, self.pack_a.location_id)
         expected_data = {
             "id": package_level.id,
             "name": package_level.package_id.name,
@@ -247,6 +248,60 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
                     extra=" (date has expired?)",
                 ),
             },
+        )
+
+    def test_start_validate_no_operation_create(self):
+        self.menu.sudo().allow_move_create = True
+        self.picking.do_unreserve()
+        barcode = self.pack_a.name
+        params = {"barcode": barcode}
+
+        # Simulate the client scanning a package's barcode, which
+        # in turns should start the operation in odoo
+        response = self.service.dispatch("start", params=params)
+
+        move_line = self.env["stock.move.line"].search(
+            [("package_id", "=", self.pack_a.id)]
+        )
+        package_level = move_line.package_level_id
+
+        response = self.service.dispatch(
+            "validate",
+            params={
+                "package_level_id": package_level.id,
+                "location_barcode": self.shelf2.barcode,
+            },
+        )
+
+        self.assert_response(
+            response,
+            next_state="start",
+            message={
+                "message_type": "success",
+                "body": "The pack has been moved, you can scan a new pack.",
+            },
+        )
+
+        self.assertRecordValues(
+            package_level.move_line_ids,
+            [
+                {
+                    "qty_picked": 1.0,
+                    "location_dest_id": self.shelf2.id,
+                    "location_id": self.shelf1.id,
+                    "state": "done",
+                }
+            ],
+        )
+        self.assertRecordValues(
+            package_level.move_line_ids.move_id,
+            [
+                {
+                    "location_dest_id": self.shelf2.id,
+                    "location_id": self.shelf1.id,
+                    "state": "done",
+                }
+            ],
         )
 
     def test_start_barcode_not_known(self):
@@ -494,11 +549,24 @@ class TestSinglePackTransfer(SinglePackTransferCommonBase):
 
         self.assertRecordValues(
             package_level.move_line_ids,
-            [{"qty_picked": 1.0, "location_dest_id": self.shelf2.id, "state": "done"}],
+            [
+                {
+                    "qty_picked": 1.0,
+                    "location_dest_id": self.shelf2.id,
+                    "location_id": self.shelf1.id,
+                    "state": "done",
+                }
+            ],
         )
         self.assertRecordValues(
             package_level.move_line_ids.move_id,
-            [{"location_dest_id": self.shelf2.id, "state": "done"}],
+            [
+                {
+                    "location_dest_id": self.shelf2.id,
+                    "location_id": self.shelf1.location_id.id,
+                    "state": "done",
+                }
+            ],
         )
 
     def test_validate_completion_info(self):

--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -631,16 +631,6 @@ class ShopfloorSingleProductTransfer(Component):
             )
 
     def _write_destination_on_lines(self, lines, location, unload=False):
-        # TODO A commit isn't yet ported to 14.0.
-        # In the meantime restore this
-        # '_write_destination_on_lines' is implemented in:
-        #
-        #   - 'location_content_transfer'
-        #   - 'zone_picking'
-        #   - 'cluster_picking' (but it is called '_unload_write_destination_on_lines')
-        #
-        # And all of them has a different implementation,
-        # To refactor later.
         try:
             # TODO lose dependency on 'shopfloor_checkout_sync' to avoid having
             # yet another glue module. In the long term we should make
@@ -654,7 +644,8 @@ class ShopfloorSingleProductTransfer(Component):
                 checkout_sync._all_lines_to_lock(lines)
             )
             checkout_sync._sync_checkout(lines, location)
-        lines.picking_id.location_dest_id = location
+        stock = self._actions_for("stock")
+        stock.set_destination_on_lines(lines, location, lock_lines=False)
         if unload:
             lines.result_package_id = False
 

--- a/shopfloor_single_product_transfer/tests/test_set_quantity.py
+++ b/shopfloor_single_product_transfer/tests/test_set_quantity.py
@@ -437,7 +437,10 @@ class TestSetQuantity(CommonCase):
         )
         self.assertEqual(move_line.location_dest_id, self.dispatch_location)
         self.assertEqual(move_line.location_id, location)
-        self.assertEqual(move_line.move_id.location_dest_id, self.dispatch_location)
+        self.assertEqual(
+            move_line.move_id.location_dest_id,
+            self.picking_type.default_location_dest_id,
+        )
         self.assertEqual(move_line.move_id.location_id, location)
 
     def test_set_quantity_scan_packaging_with_allow_move_create_and_no_prefill_qty(
@@ -740,7 +743,8 @@ class TestSetQuantity(CommonCase):
         self.assertEqual(picking.move_line_ids.location_dest_id, self.dispatch_location)
         self.assertEqual(picking.move_line_ids.location_id, self.location)
         self.assertEqual(
-            picking.move_line_ids.move_id.location_dest_id, self.dispatch_location
+            picking.move_line_ids.move_id.location_dest_id,
+            self.picking_type.default_location_dest_id,
         )
         self.assertEqual(
             picking.move_line_ids.move_id.location_id,
@@ -779,7 +783,8 @@ class TestSetQuantity(CommonCase):
         self.assertEqual(picking.move_line_ids.location_dest_id, self.dispatch_location)
         self.assertEqual(picking.move_line_ids.location_id, self.location)
         self.assertEqual(
-            picking.move_line_ids.move_id.location_dest_id, self.dispatch_location
+            picking.move_line_ids.move_id.location_dest_id,
+            self.picking_type.default_location_dest_id,
         )
         self.assertEqual(
             picking.move_line_ids.move_id.location_id,


### PR DESCRIPTION
Trying to forward port https://github.com/OCA/wms/pull/1064
Which was temporarily replaced by this work around https://github.com/OCA/stock-logistics-shopfloor/pull/11/changes/176ecb16098e9ffe67973e21c3d98e7b8a7ee152 ?