### PR TITLE
[18.0][FIX] shopfloor: Fix unsupported operand TypeError

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -116,9 +116,9 @@ class StockMove(models.Model):
         """
         # Process assigned moves
         moves = self.filtered(lambda m: m.state == "assigned")
-        if not moves:
-            return False
         new_backorders = self.env["stock.picking"]
+        if not moves:
+            return new_backorders
         for picking in moves.picking_id:
             existing_backorders = picking.backorder_ids
             moves_todo = picking.move_ids & moves


### PR DESCRIPTION
As the result of stock.move.extract_and_action done is merged in a recordset of stock.picking in shopfloor.stock.action component's function validate_moves, it should not return a Boolean value in case there are no assigned move, but a False-ish empty recordset to avoid the TypeError.