### PR TITLE
[18.0][IMP] shopfloor: cluster picking always close batch on unload

### DIFF
--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -4,7 +4,7 @@
 from markupsafe import Markup
 
 from odoo import api, fields, models
-from odoo.tools.float_utils import float_compare
+from odoo.tools.float_utils import float_compare, float_is_zero
 
 
 class StockMove(models.Model):
@@ -18,6 +18,13 @@ class StockMove(models.Model):
             move.quantity_picked = sum(
                 ml.qty_picked for ml in move.move_line_ids if ml.picked
             )
+
+    @property
+    def has_quantity_reserved(self):
+        self.ensure_one()
+        return not float_is_zero(
+            self.quantity, precision_rounding=self.product_uom.rounding
+        )
 
     def _qty_is_satisfied(self):
         compare = float_compare(

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -111,10 +111,9 @@ class StockMove(models.Model):
             "move_ids": [],
             "move_line_ids": [],
             "backorder_id": picking.id,
-            "batch_id": picking.batch_id.id,
         }
         data.update(dict(default or []))
-        new_picking = picking.with_context(disable_batch_sanity_check=True).copy(data)
+        new_picking = picking.copy(data)
         tmpl = (
             "<a href='#' data-oe-model='stock.picking' data-oe-id='{p_id}'>{p_name}</a>"
         )
@@ -138,6 +137,10 @@ class StockMove(models.Model):
                 if line.package_id == line.result_package_id:
                     line.result_package_id = False
 
+        # The batch cannot be set during copy as the moves have to be first
+        # extracted to the new picking in order to have a non draft state that
+        # will succeed the batch sanity check
+        new_picking.batch_id = picking.batch_id
         return new_picking
 
     def extract_and_action_done(self):

--- a/shopfloor/models/stock_move.py
+++ b/shopfloor/models/stock_move.py
@@ -111,9 +111,10 @@ class StockMove(models.Model):
             "move_ids": [],
             "move_line_ids": [],
             "backorder_id": picking.id,
+            "batch_id": picking.batch_id.id,
         }
         data.update(dict(default or []))
-        new_picking = picking.copy(data)
+        new_picking = picking.with_context(disable_batch_sanity_check=True).copy(data)
         tmpl = (
             "<a href='#' data-oe-model='stock.picking' data-oe-id='{p_id}'>{p_name}</a>"
         )

--- a/shopfloor/models/stock_move_line.py
+++ b/shopfloor/models/stock_move_line.py
@@ -33,6 +33,26 @@ class StockMoveLine(models.Model):
 
     is_shopfloor_created = fields.Boolean()
 
+    @property
+    def is_fully_picked(self):
+        """:return: True if the quantity picked >= quantity reserved."""
+        self.ensure_one()
+        return (
+            float_compare(
+                self.qty_picked,
+                self.quantity,
+                precision_rounding=self.product_uom_id.rounding,
+            )
+            >= 0
+        )
+
+    @property
+    def has_quantity_reserved(self):
+        self.ensure_one()
+        return not float_is_zero(
+            self.quantity, precision_rounding=self.product_uom_id.rounding
+        )
+
     def _split_partial_quantity(self):
         """Create new move line for the quantity remaining to do
 

--- a/shopfloor/models/stock_picking_batch.py
+++ b/shopfloor/models/stock_picking_batch.py
@@ -39,8 +39,3 @@ class StockPickingBatch(models.Model):
 
     def _calc_weight(self, pickings):
         return sum(pickings.mapped("total_weight"))
-
-    def _sanity_check(self):
-        if self.env.context.get("disable_batch_sanity_check"):
-            return
-        return super()._sanity_check()

--- a/shopfloor/models/stock_picking_batch.py
+++ b/shopfloor/models/stock_picking_batch.py
@@ -39,3 +39,8 @@ class StockPickingBatch(models.Model):
 
     def _calc_weight(self, pickings):
         return sum(pickings.mapped("total_weight"))
+
+    def _sanity_check(self):
+        if self.env.context.get("disable_batch_sanity_check"):
+            return
+        return super()._sanity_check()

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -77,9 +77,9 @@ class ClusterPicking(Component):
     * Declare stock out: if a good is in fact not in stock or only partially. Note
       the move lines will become unavailable or partially unavailable and will
       generate a back-order.
-    * Full bin: declaring a full bin allows to move directly to the first phase
-      (picking) to the second one (unload). The scenario will go
-      back to the first phase if some lines remain in the queue of lines to pick.
+    * Full bin: declaring a full bin allows to move directly from the first phase
+      (picking) to the second one (unload). Then the batch will be closed and
+      the scenario will go the start for the user to work on a new batch.
 
     You will find a sequence diagram describing states and endpoints
     relationships [here](../docs/cluster_picking_diag_seq.png).
@@ -1254,10 +1254,11 @@ class ClusterPicking(Component):
             picking._action_done()
 
     def _unload_end(self, batch, completion_info_popup=None):
-        """Try to close the batch if all transfers are done.
+        """After unloading close the batch transfer.
 
-        Returns to `start_line` transition if some lines could still be processed,
-        otherwise try to validate all the transfers of the batch.
+        Always close the batch transfer after unloading. The remaining work to do will
+        be assigned to a new one.
+        Returns to `start` transition.
         """
         all_pickings = batch.picking_ids
         if all(picking.state == "done" for picking in all_pickings):
@@ -1268,29 +1269,17 @@ class ClusterPicking(Component):
                 message=self.msg_store.batch_transfer_complete(),
                 popup=completion_info_popup,
             )
-
-        next_line = self._next_line_for_pick(batch)
-        if next_line:
-            return self._response_for_start_line(
-                next_line,
-                message=self.msg_store.batch_transfer_line_done(),
-                popup=completion_info_popup,
-            )
-        else:
-            # TODO add tests for this (for instance a picking is not 'done'
-            # because a move was unassigned, we want to validate the batch to
-            # produce backorders)
-            all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
-            batch.state = "done"
-            # Unassign not validated pickings from the batch, they will be
-            # processed in another batch automatically later on
-            all_pickings.invalidate_recordset(["state"])
-            pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
-            pickings_not_done.batch_id = False
-            return self._response_for_start(
-                message=self.msg_store.batch_transfer_complete(),
-                popup=completion_info_popup,
-            )
+        all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
+        batch.state = "done"
+        # Unassign not validated pickings from the batch, they will be
+        # processed in another batch automatically later on
+        all_pickings.invalidate_recordset(["state"])
+        pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
+        pickings_not_done.batch_id = False
+        return self._response_for_start(
+            message=self.msg_store.batch_transfer_complete(),
+            popup=completion_info_popup,
+        )
 
     def unload_split(self, picking_batch_id):
         """Indicates that now the batch must be treated line per line

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -77,9 +77,9 @@ class ClusterPicking(Component):
     * Declare stock out: if a good is in fact not in stock or only partially. Note
       the move lines will become unavailable or partially unavailable and will
       generate a back-order.
-    * Full bin: declaring a full bin allows to move directly to the first phase
-      (picking) to the second one (unload). The scenario will go
-      back to the first phase if some lines remain in the queue of lines to pick.
+    * Full bin: declaring a full bin allows to move directly from the first phase
+      (picking) to the second one (unload). Then the batch will be closed and
+      the scenario will go the start for the user to work on a new batch.
 
     You will find a sequence diagram describing states and endpoints
     relationships [here](../docs/cluster_picking_diag_seq.png).
@@ -1263,10 +1263,11 @@ class ClusterPicking(Component):
             picking._action_done()
 
     def _unload_end(self, batch, completion_info_popup=None):
-        """Try to close the batch if all transfers are done.
+        """After unloading close the batch transfer.
 
-        Returns to `start_line` transition if some lines could still be processed,
-        otherwise try to validate all the transfers of the batch.
+        Always close the batch transfer after unloading. The remaining work to do will
+        be assigned to a new one.
+        Returns to `start` transition.
         """
         all_pickings = batch.picking_ids
         if all(picking.state == "done" for picking in all_pickings):
@@ -1277,29 +1278,17 @@ class ClusterPicking(Component):
                 message=self.msg_store.batch_transfer_complete(),
                 popup=completion_info_popup,
             )
-
-        next_line = self._next_line_for_pick(batch)
-        if next_line:
-            return self._response_for_start_line(
-                next_line,
-                message=self.msg_store.batch_transfer_line_done(),
-                popup=completion_info_popup,
-            )
-        else:
-            # TODO add tests for this (for instance a picking is not 'done'
-            # because a move was unassigned, we want to validate the batch to
-            # produce backorders)
-            all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
-            batch.state = "done"
-            # Unassign not validated pickings from the batch, they will be
-            # processed in another batch automatically later on
-            all_pickings.invalidate_recordset(["state"])
-            pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
-            pickings_not_done.batch_id = False
-            return self._response_for_start(
-                message=self.msg_store.batch_transfer_complete(),
-                popup=completion_info_popup,
-            )
+        all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
+        batch.state = "done"
+        # Unassign not validated pickings from the batch, they will be
+        # processed in another batch automatically later on
+        all_pickings.invalidate_recordset(["state"])
+        pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
+        pickings_not_done.batch_id = False
+        return self._response_for_start(
+            message=self.msg_store.batch_transfer_complete(),
+            popup=completion_info_popup,
+        )
 
     def unload_split(self, picking_batch_id):
         """Indicates that now the batch must be treated line per line

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1,10 +1,13 @@
 # Copyright 2020-2021 Camptocamp SA (http://www.camptocamp.com)
-# Copyright 2020-2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
+# Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # Copyright 2023 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from markupsafe import Markup
 from pytz import timezone
 
 from odoo import _, exceptions, fields
+from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import str2bool
 from odoo.tools.safe_eval import (
@@ -1244,47 +1247,78 @@ class ClusterPicking(Component):
     def _unload_write_destination_on_lines(self, lines, location):
         stock = self._actions_for("stock")
         stock.set_destination_on_lines(lines, location)
+        if self.work.menu.unload_package_at_destination:
+            stock.unload_package(lines)
         lines.write({"shopfloor_unloaded": True})
-        for picking in lines.batch_id.picking_ids:
-            picking_lines = lines.filtered(lambda x, p=picking: x.picking_id == p)
-            self._unload_set_picking_to_done(picking, picking_lines)
+        for picking in lines.picking_id:
+            self._unload_set_picking_to_done(picking)
 
-    def _unload_set_picking_to_done(self, picking, picking_lines):
+    def _unload_set_picking_to_done(self, picking):
+        """Set picking to done when all picked move lines have been unloaded"""
         if picking.state == "done":
             return
-        # We set the picking to done only when the last line is
-        # unloaded to avoid backorders.
-        all_lines_unloaded = all(
-            line.shopfloor_unloaded for line in picking.move_line_ids
+        for ml in picking.move_line_ids:
+            if not ml.picked or not ml.has_quantity_reserved:
+                continue
+            # Ensure the quantity picked >= quantity reserved.
+            # At this stage, the move line should have already been split
+            # when setting the destination package.
+            if not ml.is_fully_picked:
+                raise UserError(
+                    self.env._(
+                        "Internal Error: The move line %s is not fully picked",
+                        ml.display_name,
+                    )
+                )
+            if not ml.shopfloor_unloaded:
+                # A move line is not unloaded, exit
+                return
+        stock = self._actions_for("stock")
+        for move in picking.move_ids:
+            move.split_other_move_lines(move.move_line_ids.filtered("picked"))
+        # remove assigned non picked moves
+        moves_to_validate = picking.move_ids.filtered(
+            lambda m: not (m.state == "assigned" and not m.picked)
         )
-        if self.work.menu.unload_package_at_destination and all_lines_unloaded:
-            picking_lines.result_package_id = False
-        if all_lines_unloaded:
-            picking._action_done()
+        stock.validate_moves(moves_to_validate)
+        if picking.state not in ("cancel", "done"):
+            # A split order has been created, remove picking from batch
+            picking.batch_id = False
 
     def _unload_end(self, batch, completion_info_popup=None):
-        """After unloading close the batch transfer.
+        """Remove unprocessed pickings from batch to close it.
 
-        Always close the batch transfer after unloading. The remaining work to do will
-        be assigned to a new one.
         Returns to `start` transition.
         """
-        all_pickings = batch.picking_ids
-        if all(picking.state == "done" for picking in all_pickings):
-            # do not use the 'done()' method because it does many things we
-            # don't care about
-            batch.state = "done"
-            return self._response_for_start(
-                message=self.msg_store.batch_transfer_complete(),
-                popup=completion_info_popup,
+
+        empty_pickings = batch.picking_ids.filtered(
+            lambda picking: picking.state in ("waiting", "confirmed", "assigned")
+            and all(
+                not m.picked or not m.has_quantity_reserved
+                for m in picking.move_ids
+                if m.state not in ("done", "cancel")
             )
-        all_pickings.filtered(lambda x: x.state == "assigned")._action_done()
-        batch.state = "done"
-        # Unassign not validated pickings from the batch, they will be
-        # processed in another batch automatically later on
-        all_pickings.invalidate_recordset(["state"])
-        pickings_not_done = all_pickings.filtered(lambda p: p.state != "done")
-        pickings_not_done.batch_id = False
+        )
+        if empty_pickings:
+            batch.message_post(
+                body=Markup("<b>%s:</b> %s")
+                % (
+                    self.env._("Unprocessed transfer removed from batch"),
+                    ", ".join(
+                        Markup(
+                            "<a href=#id=%s&view_type=form&model=stock.picking>%s</a>"
+                        )
+                        % (p.id, p.name)
+                        for p in empty_pickings
+                    ),
+                )
+            )
+            empty_pickings.batch_id = False
+
+        if batch.state != "done":
+            # As processed pickings are already done, the batch should now be done
+            raise UserError(self.env._("Internal Error: Batch not properly done."))
+
         return self._response_for_start(
             message=self.msg_store.batch_transfer_complete(),
             popup=completion_info_popup,

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -193,9 +193,9 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         # destination (when /set_destination_all is called, all the lines to
         # unload must have the same destination).
         # However, we keep a line without qty_done and destination package,
-        # so when the dest location is set, the endpoint should route back
-        # to the 'start_line' state to work on the remaining line.
+        # it will be moved in a new transfer and the batch closed.
         lines_to_unload = self.move_lines[:2]
+        line_not_processed = self.move_lines[2:]
         self._set_dest_package_and_done(lines_to_unload, self.bin1)
         lines_to_unload.write({"location_dest_id": self.packing_location.id})
 
@@ -206,11 +206,14 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                 "barcode": self.packing_location.barcode,
             },
         )
-        # Since the whole batch is not complete, state should not be done.
+        # The batch is closed
+        self.assertRecordValues(self.batch, [{"state": "done"}])
         # The picking with one line should be "done" because we unloaded its line.
-        # The second one still has a line to pick.
         self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        self.assertRecordValues(self.two_lines_picking, [{"state": "assigned"}])
+        # The other picking has one line being unloaded and one put in a back order
+        self.assertEqual(len(self.two_lines_picking.move_line_ids), 1)
+        self.assertRecordValues(self.two_lines_picking, [{"state": "done"}])
+        self.new_picking = line_not_processed.picking_id
         self.assertRecordValues(
             self.move_lines,
             [
@@ -228,8 +231,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "qty_picked": 10,
                     "quantity": 10,
                     "picked": True,
-                    # will be done when the second line of the picking is unloaded
-                    "state": "assigned",
+                    "state": "done",
                     "picking_id": self.two_lines_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
@@ -239,19 +241,15 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "quantity": 10,
                     "picked": False,
                     "state": "assigned",
-                    "picking_id": self.two_lines_picking.id,
+                    "picking_id": self.new_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
             ],
         )
-        self.assertRecordValues(self.batch, [{"state": "in_progress"}])
-
         self.assert_response(
-            # the remaining move line still needs to be picked
             response,
-            next_state="start_line",
-            data=self._line_data(self.move_lines[2]),
-            message={"body": "Batch Transfer line done", "message_type": "success"},
+            next_state="start",
+            message={"body": "Batch Transfer complete", "message_type": "success"},
             popup=self.ANY,
         )
 

--- a/shopfloor/tests/test_cluster_picking_unload.py
+++ b/shopfloor/tests/test_cluster_picking_unload.py
@@ -195,7 +195,6 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         # However, we keep a line without qty_done and destination package,
         # it will be moved in a new transfer and the batch closed.
         lines_to_unload = self.move_lines[:2]
-        line_not_processed = self.move_lines[2:]
         self._set_dest_package_and_done(lines_to_unload, self.bin1)
         lines_to_unload.write({"location_dest_id": self.packing_location.id})
 
@@ -208,12 +207,16 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         )
         # The batch is closed
         self.assertRecordValues(self.batch, [{"state": "done"}])
-        # The picking with one line should be "done" because we unloaded its line.
-        self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        # The other picking has one line being unloaded and one put in a back order
+        for picking in lines_to_unload.picking_id:
+            self.assertRecordValues(
+                picking, [{"state": "done", "batch_id": self.batch.id}]
+            )
+        # The 2 lines picking has one remaining line
         self.assertEqual(len(self.two_lines_picking.move_line_ids), 1)
-        self.assertRecordValues(self.two_lines_picking, [{"state": "done"}])
-        self.new_picking = line_not_processed.picking_id
+        self.assertRecordValues(
+            self.two_lines_picking, [{"state": "assigned", "batch_id": False}]
+        )
+        self.new_picking = self.two_lines_picking.backorder_ids
         self.assertRecordValues(
             self.move_lines,
             [
@@ -232,7 +235,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "quantity": 10,
                     "picked": True,
                     "state": "done",
-                    "picking_id": self.two_lines_picking.id,
+                    "picking_id": self.new_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
                 {
@@ -241,7 +244,7 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
                     "quantity": 10,
                     "picked": False,
                     "state": "assigned",
-                    "picking_id": self.new_picking.id,
+                    "picking_id": self.two_lines_picking.id,
                     "location_dest_id": self.packing_location.id,
                 },
             ],
@@ -280,8 +283,12 @@ class ClusterPickingSetDestinationAllCase(ClusterPickingUnloadingCommonCase):
         )
         # The batch should be done with only one picking.
         # The remaining picking has been removed from the current batch
-        self.assertRecordValues(self.one_line_picking, [{"state": "done"}])
-        self.assertRecordValues(self.two_lines_picking, [{"state": "confirmed"}])
+        self.assertRecordValues(
+            self.one_line_picking, [{"state": "done", "batch_id": self.batch.id}]
+        )
+        self.assertRecordValues(
+            self.two_lines_picking, [{"state": "confirmed", "batch_id": False}]
+        )
         self.assertRecordValues(self.batch, [{"state": "done"}])
         self.assertEqual(self.one_line_picking.batch_id, self.batch)
         self.assertFalse(self.two_lines_picking.batch_id)

--- a/shopfloor_cluster_picking_repack/tests/test_cluster_picking_pack_picking.py
+++ b/shopfloor_cluster_picking_repack/tests/test_cluster_picking_pack_picking.py
@@ -205,8 +205,7 @@ class TestClusterPickingPrepareUnload(ClusterPickingUnloadPackingCommonCase):
 
     def test_prepare_full_bin_unload(self):
         # process one move_line and call unload
-        # the unload should return a pack_picking state
-        # and once processed continue with next move_lines
+        # the unload will close the batch
         move_lines = self.move_lines
         self._set_dest_package_and_done(move_lines[0], self.bin1)
         move_lines.write({"location_dest_id": self.packing_location.id})
@@ -266,65 +265,20 @@ class TestClusterPickingPrepareUnload(ClusterPickingUnloadPackingCommonCase):
             },
         )
 
-        # once the unload is done, we must process the others move_lines
-        move_line = self.service._next_line_for_pick(self.batch)
-        while move_line:
-            picking = move_line.picking_id
-            self.assertEqual(response["next_state"], "start_line")
-            response = self.service.dispatch(
-                "scan_destination_pack",
-                params={
-                    "picking_batch_id": self.batch.id,
-                    "move_line_id": move_line.id,
-                    "barcode": self.bin1.name,
-                    "quantity": move_line.quantity,
-                },
-            )
-            move_line = self.service._next_line_for_pick(self.batch)
-
-        # everything is processed, we should put in pack...
-        data = self.data.pack_picking(picking)
+        # once the unload is done, the batch is done
+        self.assertRecordValues(self.batch, [{"state": "done"}])
         self.assert_response(
             response,
-            next_state="pack_picking_scan_pack",
-            data=data,
+            next_state="start",
+            message={"message_type": "success", "body": "Batch Transfer complete"},
+            popup=self.ANY,
         )
-        # we scan the pack and  process to the put in pack
-        response = self.service.dispatch(
-            "scan_packing_to_pack",
-            params={
-                "picking_batch_id": self.batch.id,
-                "picking_id": picking.id,
-                "selected_line_ids": picking.move_line_ids.ids,
-                "barcode": self.bin1.name,
-            },
+        self.assertRecordValues(
+            move_lines[0].picking_id, [{"state": "done", "batch_id": self.batch.id}]
         )
-        data = self.data.pack_picking(picking)
-        self.assert_response(
-            response,
-            next_state="pack_picking_put_in_pack",
-            data=data,
+        self.assertRecordValues(
+            move_lines[1].picking_id, [{"state": "assigned", "batch_id": False}]
         )
-        response = self.service.dispatch(
-            "put_in_pack",
-            params={
-                "picking_batch_id": self.batch.id,
-                "picking_id": picking.id,
-                "selected_line_ids": picking.move_line_ids.ids,
-                "nbr_packages": 2,
-            },
-        )
-        data = self._data_for_batch(self.batch, location)
-        self.assert_response(
-            response,
-            next_state="unload_all",
-            data=data,
-            message=self.service.msg_store.stock_picking_packed_successfully(picking),
-        )
-
-        result_package = picking.move_line_ids.mapped("result_package_id")
-        self.assertEqual(len(result_package), 1)
-        self.assertEqual(result_package[0].number_of_parcels, 2)
 
     def test_response_for_scan_destination(self):
         """Check that non internal package are not proposed as package_dest."""


### PR DESCRIPTION
Until now, after unloading because of a full bin (batch not fully picked), the batch is ketp open and the user is invited to keep picking the next line from the batch.
With this change the batch will be closed with the transfer done and the user is redirected to the start of the scenario.

J-E: Like in the other scenario, it is now calling validate_move instead of _action_done. Partially processed pickings are now moved to a split order. The picking type backorder strategy is now also respected.