### PR TITLE
[18.0][FIX] shopfloor_delivery_shipment_mobile: fix no package level

### DIFF
--- a/shopfloor_delivery_shipment_mobile/static/src/scenario/delivery_shipment.esm.js
+++ b/shopfloor_delivery_shipment_mobile/static/src/scenario/delivery_shipment.esm.js
@@ -250,6 +250,7 @@ const DeliveryShipment = {
             return this.utils.colors.color_for(color);
         },
         package_level_process(package_levels) {
+            package_levels = package_levels || [];
             const package_level_count = package_levels.length;
             const done_package_level_count = package_levels.reduce((acc, next) => {
                 return next.is_done ? acc + 1 : acc;


### PR DESCRIPTION
In some cases the package level were undefined, causing a crash at the next assignation.