### PR TITLE
[18.0][IMP] shopfloor: add check for package carrier

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -58,6 +58,7 @@
         "data/shopfloor_scenario_data.xml",
         "security/groups.xml",
         "views/shopfloor_menu.xml",
+        "views/stock_package_type.xml",
         "views/stock_picking_type.xml",
         "views/stock_location.xml",
         "views/stock_move_line.xml",

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -968,6 +968,19 @@ class MessageAction(Component):
             ),
         }
 
+    def package_type_carrier_mismatch(self, package, carrier):
+        return {
+            "message_type": "error",
+            "body": _(
+                "Package '%(package_name)s' dedicated carrier "
+                "'%(package_carrier_name)s' doesn''t match with "
+                "%(carrier_name)s",
+                package_name=package.name if package else _("No value"),
+                package_carrier_name=package.carrier_id.name if package and package.carrier_id else _("No value"),
+                carrier_name=carrier.name,
+            ),
+        }
+
     def dest_package_not_valid(self, package):
         return {
             "message_type": "error",

--- a/shopfloor/actions/packing.py
+++ b/shopfloor/actions/packing.py
@@ -17,6 +17,12 @@ class PackingAction(Component):
             carrier.delivery_type,
         )
 
+    def package_carrier_matches_picking_carrier(self, package_type, carrier):
+        return (
+            not package_type.package_carrier_id
+            or package_type.package_carrier_id == carrier
+        )
+
     def create_delivery_package(self, carrier):
         default_package_type = self._get_default_package_type(carrier)
         return self.create_package_from_package_type(default_package_type)

--- a/shopfloor/models/__init__.py
+++ b/shopfloor/models/__init__.py
@@ -10,3 +10,4 @@ from . import stock_picking
 from . import stock_picking_batch
 from . import stock_quant
 from . import stock_quant_package
+from . import stock_package_type

--- a/shopfloor/models/stock_package_type.py
+++ b/shopfloor/models/stock_package_type.py
@@ -1,0 +1,12 @@
+# TODO: Find a module to put this in
+
+from odoo import api, fields, models
+
+
+class PackageType(models.Model):
+    _inherit = 'stock.package.type'
+
+    package_carrier_id = fields.Many2one(
+        "delivery.carrier",
+        string="Dedicated carrier",
+    )

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -1175,18 +1175,20 @@ class Checkout(Component):
         self, picking, selected_lines, package_type, **kw
     ):
         carrier = self._get_carrier(picking)
+        message = None
+        is_valid = True
         if carrier:
-            # Validate against carrier
-            is_valid = self._package_type_good_for_carrier(package_type, carrier)
-        else:
-            is_valid = True
-        if carrier and not is_valid:
+            if not self._package_type_good_for_carrier(package_type, carrier):
+                is_valid = False
+                message = self.msg_store.package_type_invalid_for_carrier(package_type, carrier)
+            elif not self._package_carrier_matches_picking_carrier(package_type, carrier):
+                is_valid = False
+                message = self.msg_store.package_type_carrier_mismatch(package_type, carrier)
+        if not is_valid:
             return self._response_for_select_package(
                 picking,
                 selected_lines,
-                message=self.msg_store.package_type_invalid_for_carrier(
-                    package_type, carrier
-                ),
+                message=message,
             )
         return self._create_and_assign_new_package_type(
             picking, selected_lines, package_type
@@ -1199,6 +1201,10 @@ class Checkout(Component):
 
     def _get_carrier(self, picking):
         return picking.ship_carrier_id or picking.carrier_id
+
+    def _package_carrier_matches_picking_carrier(self, package_type, carrier):
+        actions = self._actions_for("packing")
+        return actions.package_carrier_matches_picking_carrier(package_type, carrier)
 
     def _package_type_good_for_carrier(self, package_type, carrier):
         actions = self._actions_for("packing")

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -475,3 +475,83 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         returned_lines = res["data"]["summary"]["picking"]["move_lines"]
         expected_line_ids = [line["id"] for line in returned_lines]
         self.assertEqual(expected_line_ids, picking.move_line_ids.ids)
+
+    def test_scan_package_action_scan_invalid_package_type_carrier(self):
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.carrier_id = picking.carrier_id.search([], limit=1)
+        another_carrier = picking.carrier_id.search([("id", "!=", picking.carrier_id.id)], limit=1)
+        pack1_moves = picking.move_ids
+        # put in 2 packs, for this test, we'll work on pack1
+        self._fill_stock_for_moves(pack1_moves, in_package=True)
+        picking.action_assign()
+        selected_lines = pack1_moves.move_line_ids
+        selected_lines.qty_picked = selected_lines.quantity
+        packaging = (
+            self.env["stock.package.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Package",
+                    "barcode": "PACKAGE",
+                }
+            )
+        )
+        mock1 = mock.patch.object(
+            type(packaging),
+            "package_carrier_type",
+            new_callable=mock.PropertyMock,
+        )
+        mock2 = mock.patch.object(
+            type(picking.carrier_id),
+            "delivery_type",
+            new_callable=mock.PropertyMock,
+        )
+        mock3 = mock.patch.object(
+            type(packaging),
+            "package_carrier_id",
+            new_callable=mock.PropertyMock,
+        )
+        with mock1 as mocked_package_carrier_type, mock2 as mocked_delivery_type, mock3 as mocked_package_carrier_id:
+            # Picking carrier id not matching the packaging carried id -> bad
+            mocked_package_carrier_type.return_value = "Postlogistics"
+            mocked_delivery_type.return_value = "Postlogistics"
+            mocked_package_carrier_id.return_value = another_carrier
+            response = self.service.dispatch(
+                "scan_package_action",
+                params={
+                    "picking_id": picking.id,
+                    "selected_line_ids": selected_lines.ids,
+                    "barcode": packaging.barcode,
+                },
+            )
+            self._assert_selected_response(
+                response,
+                selected_lines,
+                message=self.msg_store.package_type_carrier_mismatch(
+                    packaging, picking.carrier_id
+                ),
+            )
+            # Picking carrier id matches with packaging carrier id -> good
+            mocked_package_carrier_id.return_value = picking.carrier_id
+            response = self.service.dispatch(
+                "scan_package_action",
+                params={
+                    "picking_id": picking.id,
+                    "selected_line_ids": selected_lines.ids,
+                    "barcode": packaging.barcode,
+                },
+            )
+            self.assertEqual(
+                response["message"],
+                self.msg_store.goods_packed_in(selected_lines.result_package_id),
+            )
+            # Picking carrier id is not set on the packaging -> good
+            mocked_package_carrier_id.return_value = False
+            response = self.service.dispatch(
+                "scan_package_action",
+                params={
+                    "picking_id": picking.id,
+                    "selected_line_ids": selected_lines.ids,
+                    "barcode": packaging.barcode,
+                },
+            )

--- a/shopfloor/views/stock_package_type.xml
+++ b/shopfloor/views/stock_package_type.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="stock_package_type_form" model="ir.ui.view">
+        <field name="name">stock.packag.carrier.id.form</field>
+        <field name="model">stock.package.type</field>
+        <field name="inherit_id" ref="stock.stock_package_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='delivery']"  position="inside">
+                <group>
+                    <field name="package_carrier_id"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- Added check in shopfloor checkout for the `package_carrier_id` which allows to restrict packages to dedicated carriers, instead of relying only on the carrier type (`package_carrier_type`)

TODO:
Where to introduce the package_carrier_id field is not yet clear and need to be decided. For now temporarily in shopfloor for testing and demonstration

