### PR TITLE
[18.0][FIX] shopfloor: Propagate lot for inventory action

### DIFF
--- a/shopfloor/actions/inventory.py
+++ b/shopfloor/actions/inventory.py
@@ -22,9 +22,9 @@ class InventoryAction(Component):
         # see comment in models/stock_inventory.py
         return self.env["stock.quant"].with_context(_sf_inventory=True)
 
-    def create_draft_check_empty(self, location, product, ref=None):
+    def create_draft_check_empty(self, location, product, ref=None, lot=None):
         """Create a draft inventory for a product with a zero quantity"""
-        return self._create_draft_inventory(location, product)
+        return self._create_draft_inventory(location, product, lot=lot)
 
     def _inventory_exists(self, location, product, package=None, lot=None):
         """Return if an inventory for location and product exist"""
@@ -64,17 +64,23 @@ class InventoryAction(Component):
                         # Set a user to prevent the zero quant cleanup
                         "user_id": self.env.user.id,
                         "inventory_quantity": 0,
+                        "inventory_quantity_set": True,
                         "inventory_date": fields.Date.today(),
                     }
                 )
             return quants
         else:
+            # FIXME: we should probably not get there as every move line
+            #  must match a quant as even if we do not have any quantity
+            #  in stock, we must have a negative reserved quantity
             return self.inventory_model.sudo().create(
                 {
+                    # Set a user to prevent the zero quant cleanup
+                    "user_id": self.env.user.id,
                     "location_id": location.id,
                     "product_id": product.id,
                     "lot_id": lot.id if lot else False,
-                    "inventory_quantity": 1,
+                    "inventory_quantity": 0,
                     "inventory_quantity_set": True,
                     "inventory_date": fields.Date.today(),
                     "package_id": package.id if package else False,

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -990,6 +990,7 @@ class ClusterPicking(Component):
                 move_line.location_id,
                 move_line.product_id,
                 ref=move_line.picking_id.name,
+                lot=move_line.lot_id,
             )
 
         return self._pick_next_line(

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1342,6 +1342,7 @@ class ZonePicking(Component):
                 move_line.location_id,
                 move_line.product_id,
                 ref=picking_type.name,
+                lot=move_line.lot_id,
             )
         move_lines = self._find_location_move_lines(zone_location, picking_type)
         return self._response_for_select_line(move_lines)

--- a/shopfloor/tests/test_zone_picking_base.py
+++ b/shopfloor/tests/test_zone_picking_base.py
@@ -215,6 +215,7 @@ class ZonePickingCommonCase(CommonCase):
             picking1.move_ids, in_package=True, location=cls.zone_sublocation1
         )
         # 2 products with lots available in zone_sublocation2
+        (cls.product_b | cls.product_c).tracking = "lot"
         cls.picking2 = picking2 = cls._create_picking(
             lines=[(cls.product_b, 10), (cls.product_c, 10)]
         )

--- a/shopfloor/tests/test_zone_picking_zero_check.py
+++ b/shopfloor/tests/test_zone_picking_zero_check.py
@@ -67,3 +67,17 @@ class ZonePickingZeroCheckCase(ZonePickingCommonCase):
             move_line.location_id, move_line.product_id
         )
         self.assertTrue(result)
+
+    def test_is_zero_lot(self):
+        move_line_1 = self.picking2.move_line_ids[0]
+
+        self.service.dispatch(
+            "is_zero",
+            params={"move_line_id": move_line_1.id, "zero": False},
+        )
+        inventory = self.service._actions_for("inventory")
+        quant = inventory._get_existing_quant(
+            move_line_1.location_id, move_line_1.product_id, lot=move_line_1.lot_id
+        )
+        self.assertTrue(quant)
+        quant._apply_inventory()


### PR DESCRIPTION
As the lot was not propagated from the move line, no quant without lot could be found, and we ended up creating a quant without lot for a product tracked by lot.