### PR TITLE
[18.0][FIX] shopfloor_reception_mobile: Fix set_quantity cancel action

### DIFF
--- a/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception.esm.js
@@ -162,7 +162,7 @@ const Reception = {
                                 <btn-back/>
                             </v-col>
                             <v-col class="text-center" cols="12">
-                                <cancel-button/>
+                                <cancel-button v-on:cancel="state.on_cancel"/>
                             </v-col>
                         </v-row>
                     </div>

--- a/shopfloor_reception_mobile/static/src/scenario/reception_states.esm.js
+++ b/shopfloor_reception_mobile/static/src/scenario/reception_states.esm.js
@@ -181,7 +181,6 @@ export const reception_states = function () {
             events: {
                 qty_edit: "on_qty_edit",
                 go_back: "on_back",
-                cancel: "on_cancel",
             },
             on_qty_edit: (qty) => {
                 this.scan_destination_qty = parseInt(qty, 10);


### PR DESCRIPTION
Explicitely call `set_quantity.on_cancel` when cancel-button component emits `cancel`