### PR TITLE
[18.0][IMP] shopfloor: filter packages based on dedicated carriers

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -44,6 +44,8 @@
         "product_packaging_level",
         #  OCA / delivery
         "stock_picking_delivery_link",
+        #  OCA / delivery-carrier
+        "stock_picking_delivery_package_type_domain",
         # TODO v18: new dependency due to ``available_carriers`` that needs a SO.
         # see picking_form.py
         "sale_stock",

--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -961,8 +961,8 @@ class MessageAction(Component):
         return {
             "message_type": "error",
             "body": _(
-                "Package type '%(package_type_name)s' is not allowed for carrier "
-                "%(carrier_name)s.or carrier %(carrier_name)s.",
+                "Package type '%(package_type_name)s' is not allowed for "
+                "delivery method %(carrier_name)s.",
                 package_type_name=package_type.name if package_type else _("No value"),
                 carrier_name=carrier.name,
             ),

--- a/shopfloor/actions/packing.py
+++ b/shopfloor/actions/packing.py
@@ -11,15 +11,42 @@ class PackingAction(Component):
     _inherit = "shopfloor.process.action"
     _usage = "packing"
 
-    def package_type_valid_for_carrier(self, package_type, carrier):
-        return package_type.package_carrier_type in (
-            "none",
-            carrier.delivery_type,
-        )
+    def _delivery_type_for_carrier(self, carrier):
+        # "fixed" and "base_on_rule" are pricing rules, not real carrier integrations,
+        # so they have no package type restrictions, treat them as no carrier.
+        # See: odoo/src/addons/stock_delivery/models/stock_picking.py line 146-147
+        if not carrier:
+            return False
+        elif carrier.delivery_type in ("fixed", "base_on_rule", "pricelist"):
+            return "none"
+        return carrier.delivery_type
+
+    def _get_carrier(self, picking):
+        return picking.ship_carrier_id or picking.carrier_id
+
+    def _get_package_type_domain(self, picking):
+        carrier = self._get_carrier(picking)
+        wizard_obj = self.env["choose.delivery.package"]
+        delivery_type = self._delivery_type_for_carrier(carrier)
+        wizard = wizard_obj.with_context(
+            current_package_carrier_type=delivery_type
+        ).new({"picking_id": picking.id})
+        return wizard.package_type_domain
+
+    def package_type_valid_for_carrier(self, package_type, picking):
+        carrier = self._get_carrier(picking)
+        if not carrier:
+            return True
+        domain = self._get_package_type_domain(picking)
+        return bool(package_type.filtered_domain(domain))
 
     def create_delivery_package(self, carrier):
         default_package_type = self._get_default_package_type(carrier)
         return self.create_package_from_package_type(default_package_type)
+
+    def available_package_types_for_picking(self, picking, order="name"):
+        domain = self._get_package_type_domain(picking)
+        return self.env["stock.package.type"].search(domain, order=order)
 
     def _get_default_package_type(self, carrier):
         # TODO: refactor `delivery_[carrier_name]` modules

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -725,17 +725,11 @@ class Checkout(Component):
             4. assign new package and skip `select_package` state
 
         """
-        carrier = self._get_carrier(picking)
-        if carrier:
-            # Validate against carrier
-            is_valid = self._package_type_good_for_carrier(package_type, carrier)
-        else:
-            is_valid = True
-        if carrier and not is_valid:
+        if not self._package_type_valid_for_carrier(picking, package_type):
             return self._response_for_select_line(
                 picking,
                 message=self.msg_store.package_type_invalid_for_carrier(
-                    package_type, carrier
+                    package_type, self._get_carrier(picking)
                 ),
             )
         message = None
@@ -1178,18 +1172,12 @@ class Checkout(Component):
     def _scan_package_action_from_package_type(
         self, picking, selected_lines, package_type, **kw
     ):
-        carrier = self._get_carrier(picking)
-        if carrier:
-            # Validate against carrier
-            is_valid = self._package_type_good_for_carrier(package_type, carrier)
-        else:
-            is_valid = True
-        if carrier and not is_valid:
+        if not self._package_type_valid_for_carrier(picking, package_type):
             return self._response_for_select_package(
                 picking,
                 selected_lines,
                 message=self.msg_store.package_type_invalid_for_carrier(
-                    package_type, carrier
+                    package_type, self._get_carrier(picking)
                 ),
             )
         return self._create_and_assign_new_package_type(
@@ -1204,22 +1192,13 @@ class Checkout(Component):
     def _get_carrier(self, picking):
         return picking.ship_carrier_id or picking.carrier_id
 
-    def _package_type_good_for_carrier(self, package_type, carrier):
+    def _package_type_valid_for_carrier(self, picking, package_type):
         actions = self._actions_for("packing")
-        return actions.package_type_valid_for_carrier(package_type, carrier)
+        return actions.package_type_valid_for_carrier(package_type, picking)
 
     def _get_available_package_type(self, picking):
-        model = self.env["stock.package.type"]
-        carrier = picking.ship_carrier_id or picking.carrier_id
-        if not carrier:
-            return model.search(
-                [("package_carrier_type", "=", False)],
-                order="name",
-            )
-        return model.search(
-            [("package_carrier_type", "=", carrier.delivery_type or "none")],
-            order="name",
-        )
+        actions = self._actions_for("packing")
+        return actions.available_package_types_for_picking(picking)
 
     def list_package_type(self, picking_id, selected_line_ids):
         """List available package type for given picking.

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1304,7 +1304,7 @@ class ZonePicking(Component):
         carrier = picking.ship_carrier_id or picking.carrier_id
         if carrier:
             actions = self._actions_for("packing")
-            if actions.package_type_valid_for_carrier(package.package_type_id, carrier):
+            if actions.package_type_valid_for_carrier(package.package_type_id, picking):
                 good_for_packing = True
             else:
                 message = self.msg_store.package_type_invalid_for_carrier(

--- a/shopfloor/tests/test_checkout_list_package_type.py
+++ b/shopfloor/tests/test_checkout_list_package_type.py
@@ -28,6 +28,7 @@ class CheckoutListDeliveryPackagingCase(CheckoutCommonCase, CheckoutSelectPackag
             ]
         )
         self.picking.carrier_id = self.carrier
+        self.picking.picking_type_id.sudo().filter_package_type_on_put_in_pack = True
         self.packaging_type = (
             self.env["product.packaging.level"]
             .sudo()

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -3,11 +3,29 @@
 from itertools import product
 from unittest import mock
 
+from odoo_test_helper import FakeModelLoader
+
 from .test_checkout_base import CheckoutCommonCase
 from .test_checkout_select_package_base import CheckoutSelectPackageMixin
 
 
 class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMixin):
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
+
+        from .models import DeliveryCarrierTest, StockPackageType
+
+        self.loader.update_registry((DeliveryCarrierTest, StockPackageType))
+
+        self.carrier = self.env["delivery.carrier"].search([], limit=1)
+        self.carrier.sudo().delivery_type = "test"
+
+    def tearDown(self):
+        self.loader.restore_registry()
+        super().tearDown()
+
     def _test_select_product(
         self, barcode_func, origin_qty_func, expected_qty_func, in_lot=False
     ):
@@ -381,23 +399,18 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
                 }
             )
         )
-        # Delivery type and package_carrier_type values
-        # depend on specific implementations that we don't have as dependency.
-        # What is important here is to simulate their value when mismatching.
-        mock1 = mock.patch.object(
-            type(packaging),
-            "package_carrier_type",
-            new_callable=mock.PropertyMock,
-        )
-        mock2 = mock.patch.object(
-            type(picking.carrier_id),
-            "delivery_type",
-            new_callable=mock.PropertyMock,
-        )
-        with mock1 as mocked_package_carrier_type, mock2 as mocked_delivery_type:
-            # Not matching at all -> bad
-            mocked_package_carrier_type.return_value = "DHL"
-            mocked_delivery_type.return_value = "UPS"
+        packing_action = type(self.service._actions_for("packing"))
+        with mock.patch.object(
+            packing_action,
+            "_get_package_type_domain",
+            side_effect=[
+                # first call: domain excludes packaging -> bad
+                [("id", "!=", packaging.id)],
+                # second call: domain includes packaging -> good
+                [("id", "=", packaging.id)],
+            ],
+        ):
+            # not in wizard domain -> bad
             response = self.service.dispatch(
                 "scan_package_action",
                 params={
@@ -414,8 +427,7 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
                     packaging, picking.carrier_id
                 ),
             )
-            # No carrier type set on the packaging -> good
-            mocked_package_carrier_type.return_value = "none"
+            # in wizard domain -> good
             response = self.service.dispatch(
                 "scan_package_action",
                 params={
@@ -475,3 +487,66 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         returned_lines = res["data"]["summary"]["picking"]["move_lines"]
         expected_line_ids = [line["id"] for line in returned_lines]
         self.assertEqual(expected_line_ids, picking.move_line_ids.ids)
+
+    def test_scan_package_action_scan_invalid_package_type_carrier(self):
+        picking = self._create_picking(lines=[(self.product_a, 10)])
+        picking.carrier_id = self.carrier
+        pack1_moves = picking.move_ids
+        # put in 2 packs, for this test, we'll work on pack1
+        self._fill_stock_for_moves(pack1_moves, in_package=True)
+        picking.action_assign()
+        selected_lines = pack1_moves.move_line_ids
+        selected_lines.qty_picked = selected_lines.quantity
+        # valid for the "test" carrier
+        packaging = (
+            self.env["stock.package.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Package",
+                    "barcode": "PACKAGE",
+                    "package_carrier_type": "test",
+                }
+            )
+        )
+        # not valid for the "test" carrier
+        other_packaging = (
+            self.env["stock.package.type"]
+            .sudo()
+            .create(
+                {
+                    "name": "Other Package",
+                    "barcode": "PACKAGE-OTHER",
+                    "package_carrier_type": "none",
+                }
+            )
+        )
+        # package type not valid for carrier -> bad
+        response = self.service.dispatch(
+            "scan_package_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_ids": selected_lines.ids,
+                "barcode": other_packaging.barcode,
+            },
+        )
+        self._assert_selected_response(
+            response,
+            selected_lines,
+            message=self.msg_store.package_type_invalid_for_carrier(
+                other_packaging, picking.carrier_id
+            ),
+        )
+        # package type valid for carrier -> good
+        response = self.service.dispatch(
+            "scan_package_action",
+            params={
+                "picking_id": picking.id,
+                "selected_line_ids": selected_lines.ids,
+                "barcode": packaging.barcode,
+            },
+        )
+        self.assertEqual(
+            response["message"],
+            self.msg_store.goods_packed_in(selected_lines.result_package_id),
+        )

--- a/shopfloor/tests/test_checkout_scan_package_action.py
+++ b/shopfloor/tests/test_checkout_scan_package_action.py
@@ -18,9 +18,22 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
         from .models import DeliveryCarrierTest, StockPackageType
 
         self.loader.update_registry((DeliveryCarrierTest, StockPackageType))
-
-        self.carrier = self.env["delivery.carrier"].search([], limit=1)
-        self.carrier.sudo().delivery_type = "test"
+        carrier_product = (
+            self.env["product.product"]
+            .sudo()
+            .create({"name": "Test carrier product", "type": "service"})
+        )
+        self.test_carrier = (
+            self.env["delivery.carrier"]
+            .sudo()
+            .create(
+                {
+                    "name": "Test carrier",
+                    "delivery_type": "test",
+                    "product_id": carrier_product.id,
+                }
+            )
+        )
 
     def tearDown(self):
         self.loader.restore_registry()
@@ -490,7 +503,8 @@ class CheckoutScanPackageActionCase(CheckoutCommonCase, CheckoutSelectPackageMix
 
     def test_scan_package_action_scan_invalid_package_type_carrier(self):
         picking = self._create_picking(lines=[(self.product_a, 10)])
-        picking.carrier_id = self.carrier
+        picking.carrier_id = self.test_carrier
+        picking.picking_type_id.sudo().filter_package_type_on_put_in_pack = True
         pack1_moves = picking.move_ids
         # put in 2 packs, for this test, we'll work on pack1
         self._fill_stock_for_moves(pack1_moves, in_package=True)

--- a/shopfloor_cluster_picking_repack/services/cluster_picking.py
+++ b/shopfloor_cluster_picking_repack/services/cluster_picking.py
@@ -258,22 +258,11 @@ class ClusterPicking(Component):
         The returned package types are ordered by number of parcels then
         by name.
         """
-        model = self.env["stock.package.type"]
-        carrier = picking.ship_carrier_id or picking.carrier_id
-        wizard_obj = self.env["choose.delivery.package"]
-        delivery_type = (
-            carrier.delivery_type
-            if carrier.delivery_type not in ("fixed", False)
-            else "none"
-        )
-        wizard = wizard_obj.with_context(
-            current_package_carrier_type=delivery_type
-        ).new({"picking_id": picking.id})
-        if not carrier:
-            return model.browse()
-        return model.search(
-            wizard.package_type_domain,
-            order="number_of_parcels,name",
+        packing_action = self._actions_for("packing")
+        if not packing_action._get_carrier(picking):
+            return self.env["stock.package.type"].browse()
+        return packing_action.available_package_types_for_picking(
+            picking, order="number_of_parcels,name"
         )
 
     def _last_picked_line(self, picking) -> StockMoveLine:


### PR DESCRIPTION
Rely on backend choose.delivery.package wizard to collect the list of valid package types.

Depends on:
* https://github.com/OCA/delivery-carrier/pull/1214

that allows to limit the list of package types based on the carrier (and not only the carrier type).

The new config flag `filter_package_type_on_put_in_pack` in `stock_picking_delivery_package_type_domain` needs to be set to keep filtering package types by carrier.
