### PR TITLE
[18.0][FWP] shopfloor_reception: fix UTC boundaries for "Today" filters

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -4,6 +4,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 
+from datetime import datetime, time
+
 import pytz
 
 from odoo import fields
@@ -71,31 +73,40 @@ class Reception(Component):
 
     def _scheduled_date_today_domain(self):
         domain = []
-        today_start, today_end = self._get_today_start_end_datetime()
+        today_start, today_end = self._get_today_start_end_datetime_utc()
         domain.append(("scheduled_date", ">=", today_start))
         domain.append(("scheduled_date", "<=", today_end))
         return domain
 
-    def _get_today_start_end_datetime(self, naive=True):
+    def _get_today_start_end_datetime_utc(self):
+        """
+        Returns the start and end of the current day for the warehouse/company
+        timezone, converted to UTC naive datetimes.
+        """
         # TODO: Put warehouse tz retrieval in shopfloor module?
         company = self.env.company
         warehouse = self.picking_types.warehouse_id
-        tz = (
+
+        tz_name = (
             warehouse.partner_id.tz
             if (len(warehouse) == 1 and warehouse.partner_id.tz)
             else company.partner_id.tz or "UTC"
         )
-        today = fields.Datetime.today()
-        today_start = today_start_localized = fields.Datetime.start_of(today, "day")
-        today_end = today_end_localized = fields.Datetime.end_of(today, "day")
-        if not naive:
-            today_start_localized = (
-                pytz.timezone(tz).localize(today_start).astimezone(pytz.utc)
-            )
-            today_end_localized = (
-                pytz.timezone(tz).localize(today_end).astimezone(pytz.utc)
-            )
-        return (today_start_localized, today_end_localized)
+        tz = pytz.timezone(tz_name)
+
+        now_local = pytz.utc.localize(datetime.now()).astimezone(tz)
+
+        local_start = datetime.combine(
+            now_local.date(), time.min, tzinfo=now_local.tzinfo
+        )
+        local_end = datetime.combine(
+            now_local.date(), time.max, tzinfo=now_local.tzinfo
+        )
+
+        utc_start = local_start.astimezone(pytz.utc).replace(tzinfo=None)
+        utc_end = local_end.astimezone(pytz.utc).replace(tzinfo=None)
+
+        return utc_start, utc_end
 
     @property
     def filter_today_scheduled_pickings(self):
@@ -404,7 +415,7 @@ class Reception(Component):
             # could return more than one picking.
             # If there's only one picking due today, we go to the next screen.
             # Otherwise, we ask the user to scan a package instead.
-            today_start, today_end = self._get_today_start_end_datetime()
+            today_start, today_end = self._get_today_start_end_datetime_utc()
             picking_filter_result_due_today = picking_filter_result.filtered(
                 lambda p: today_start <= p.scheduled_date < today_end
             )

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 # pylint: disable=missing-return
+from datetime import datetime, timedelta
+
 from freezegun import freeze_time
 
 from odoo import fields
@@ -9,7 +11,6 @@ from .common import CommonCase
 
 _TODAY = "2022-12-07"
 _TOMORROW = "2022-12-08"
-_TODAY_ELEVEN = "2022-12-07 23:30:00"
 
 
 class TestSelectDocument(CommonCase):
@@ -82,15 +83,21 @@ class TestSelectDocument(CommonCase):
             data=self._data_for_select_move(picking_today),
         )
 
-    @freeze_time(_TODAY_ELEVEN, tz_offset=0)
+    # Since we use "Europe/Brussels" tz and _TODAY is in winter
+    # the shift is UTC+1
+    @freeze_time(_TODAY, tz_offset=-1)
     def test_scan_picking_origin_multiple_pickings_one_today_tz(self):
         # freezed today is UTC time, set warehouse user to Brussels
-        self.wh.partner_id.sudo().tz = "Europe/Brussels"
+        tz_name = "Europe/Brussels"
+        self.wh.partner_id.sudo().tz = tz_name
 
         # Create a picking with the UTC hour
-        picking_today = self._create_picking(scheduled_date=_TODAY_ELEVEN)
-
-        picking_tomorrow = self._create_picking(scheduled_date=_TOMORROW)
+        picking_today = self._create_picking(
+            scheduled_date=datetime.now() + timedelta(hours=23, minutes=30)
+        )
+        picking_tomorrow = self._create_picking(
+            scheduled_date=datetime.now() + timedelta(days=1),
+        )
         pickings = picking_today | picking_tomorrow
         pickings = pickings.sorted(lambda p: (p.scheduled_date, p.id), reverse=False)
         pickings.write({"origin": "Somewhere together"})


### PR DESCRIPTION
The `_get_today_start_end_datetime` function returned naive datetimes without accounting for the user's local timezone. Since Odoo stores datetimes in UTC, this caused incorrect filtering on the "Pickings to Process Today" screen for users in non-UTC timezones.

Now, the function correctly calculates the start and end of the local day and converts those boundaries to UTC .

Forward ported from https://github.com/OCA/wms/pull/1150