### PR TITLE
[18.0][FWP] shopfloor_reception: correct _set_quantity__by_lot signature

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -744,8 +744,8 @@ class Reception(Component):
         selected_line.location_dest_id = location
         return self._response_for_select_move(picking)
 
-    def _set_quantity__by_lot(self, picking, selected_line, barcode):
-        if selected_line.lot_id.name == barcode or selected_line.lot_name == barcode:
+    def _set_quantity__by_lot(self, picking, selected_line, lot):
+        if selected_line.lot_id.name == lot.name or selected_line.lot_name == lot.name:
             selected_line.qty_picked += 1
             return self._response_for_set_quantity(picking, selected_line)
 

--- a/shopfloor_reception/tests/test_set_quantity.py
+++ b/shopfloor_reception/tests/test_set_quantity.py
@@ -54,6 +54,28 @@ class TestSetQuantity(CommonCase):
             },
         )
 
+    def test_set_quantity_scan_lot(self):
+        picking = self._create_picking()
+        selected_move_line = picking.move_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        lot = self._create_lot(
+            product_id=selected_move_line.product_id.id, name="Test Lot"
+        )
+        selected_move_line.write({"shopfloor_user_id": self.env.uid, "lot_id": lot.id})
+        self.service.dispatch(
+            "set_quantity",
+            params={
+                "picking_id": picking.id,
+                "selected_line_id": selected_move_line.id,
+                # ↓ UI calls with 0 by default
+                "quantity": 0.0,
+                "barcode": "Test Lot",
+            },
+        )
+
+        self.assertEqual(selected_move_line.qty_picked, 1)
+
     def test_set_quantity_scan_packaging(self):
         picking = self._create_picking()
         selected_move_line = picking.move_line_ids.filtered(


### PR DESCRIPTION
The handler `_set_quantity__by_lot` was incorrectly expecting a string as its third argument. However, the dispatcher `_set_quantity__by_barcode` passes `search_result.record` (a recordset).

This mismatch caused a 500 error during the "set qty" state when scanning a lot barcode.

Forward ported from : https://github.com/OCA/wms/pull/1156