### PR TITLE
[18.0][IMP] shopfloor: confirmed zero check creates draft inventory

### DIFF
--- a/shopfloor/actions/inventory.py
+++ b/shopfloor/actions/inventory.py
@@ -22,9 +22,11 @@ class InventoryAction(Component):
         # see comment in models/stock_inventory.py
         return self.env["stock.quant"].with_context(_sf_inventory=True)
 
-    def create_draft_check_empty(self, location, product, ref=None, lot=None):
+    def create_draft_check_empty(
+        self, location, product, ref=None, lot=None, package=None
+    ):
         """Create a draft inventory for a product with a zero quantity"""
-        return self._create_draft_inventory(location, product, lot=lot)
+        return self._create_draft_inventory(location, product, package=package, lot=lot)
 
     def _inventory_exists(self, location, product, package=None, lot=None):
         """Return if an inventory for location and product exist"""
@@ -39,8 +41,12 @@ class InventoryAction(Component):
             domain.append(("lot_id", "=", lot.id))
         return self.inventory_model.search_count(domain)
 
-    def _get_existing_quant(self, location, product, package=None, lot=None, limit=1):
-        domain = [("location_id", "=", location.id), ("product_id", "=", product.id)]
+    def _get_existing_quant(
+        self, location, product=None, package=None, lot=None, limit=1
+    ):
+        domain = [("location_id", "=", location.id)]
+        if product is not None:
+            domain.append(("product_id", "=", product.id))
         if package is not None:
             domain.append(("package_id", "=", package.id))
         else:
@@ -97,6 +103,35 @@ class InventoryAction(Component):
         """
         if not self._inventory_exists(location, product, package=package, lot=lot):
             self._create_draft_inventory(location, product, package=package, lot=lot)
+
+    def confirm_not_empty(self, location, product, ref=None, package=None, lot=None):
+        return self.create_draft_check_empty(
+            location, product, ref=ref, package=package, lot=lot
+        )
+
+    def confirm_empty(self, location, product, ref=None, package=None, lot=None):
+        quants = self._get_existing_quant(location, limit=None)
+        if quants.filtered(
+            lambda quant: quant.user_id and quant.user_id != self.env.user
+        ):
+            # the location is empty but there is still a planned check empty inventory
+            # do nothing, someone will have to check
+            return
+        if not quants:
+            quants = self.create_draft_check_empty(
+                location, product, package=package, lot=lot
+            )
+        else:
+            quants.write(
+                {
+                    "user_id": self.env.user.id,
+                    "inventory_quantity": 0,
+                    "inventory_quantity_set": True,
+                    "inventory_date": fields.Date.today(),
+                }
+            )
+        quants.sudo().action_apply_inventory()
+        return quants
 
     def create_stock_issue(self, move, location, package, lot):
         """Create an inventory for a stock issue

--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -984,12 +984,21 @@ class ClusterPicking(Component):
                 batch, message=self.msg_store.operation_not_found()
             )
 
-        if not zero:
-            inventory = self._actions_for("inventory")
-            inventory.create_draft_check_empty(
+        inventory = self._actions_for("inventory")
+        if zero:
+            inventory.confirm_empty(
                 move_line.location_id,
                 move_line.product_id,
                 ref=move_line.picking_id.name,
+                package=move_line.package_id,
+                lot=move_line.lot_id,
+            )
+        else:
+            inventory.confirm_not_empty(
+                move_line.location_id,
+                move_line.product_id,
+                ref=move_line.picking_id.name,
+                package=move_line.package_id,
                 lot=move_line.lot_id,
             )
 

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -1334,12 +1334,21 @@ class ZonePicking(Component):
         picking_type = move_line.move_id.picking_id.picking_type_id
         if not picking_type.exists():
             return self._response_for_start(message=self.msg_store.record_not_found())
-        if not zero:
-            inventory = self._actions_for("inventory")
-            inventory.create_draft_check_empty(
+        inventory = self._actions_for("inventory")
+        if zero:
+            inventory.confirm_empty(
                 move_line.location_id,
                 move_line.product_id,
                 ref=picking_type.name,
+                package=move_line.package_id,
+                lot=move_line.lot_id,
+            )
+        else:
+            inventory.confirm_not_empty(
+                move_line.location_id,
+                move_line.product_id,
+                ref=picking_type.name,
+                package=move_line.package_id,
                 lot=move_line.lot_id,
             )
         move_lines = self._find_location_move_lines(zone_location, picking_type)

--- a/shopfloor/tests/__init__.py
+++ b/shopfloor/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_actions_packing
 from . import test_actions_search_move_line
 from . import test_actions_search
 from . import test_actions_stock
+from . import test_actions_inventory
 
 from . import test_single_pack_transfer
 from . import test_single_pack_transfer_putaway

--- a/shopfloor/tests/test_actions_inventory.py
+++ b/shopfloor/tests/test_actions_inventory.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .common import CommonCase
+
+
+class TestInventory(CommonCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with cls.work_on_actions(cls) as work:
+            cls.inventory = work.component(usage="inventory")
+        cls.location = cls.shelf1
+        cls.product = (
+            cls.env["product.product"]
+            .sudo()
+            .create({"name": "screw", "is_storable": True})
+        )
+        cls.quant_model = cls.env["stock.quant"]
+        cls.quants_before = cls.quant_model.browse()
+
+    @classmethod
+    def _update_quants(cls):
+        cls.quants_before = cls.quant_model._gather(cls.product, cls.location)
+
+    @classmethod
+    def _get_new_quants(cls):
+        return cls.quant_model._gather(cls.product, cls.location) - cls.quants_before
+
+    def assert_inventory_quant_zero(self, quants):
+        for quant in quants:
+            self.assertEqual(quant.inventory_quantity, 0)
+            self.assertTrue(quant.inventory_quantity_set)
+
+    @classmethod
+    def _add_stock_to_product(cls):
+        """Set the stock quantity of the product."""
+        values = {
+            "product_id": cls.product.id,
+            "location_id": cls.location.id,
+            "inventory_quantity": 10.0,
+        }
+        cls.quant_model.sudo().with_context(inventory_mode=True).create(
+            values
+        )._apply_inventory()
+        cls._update_quants()
+
+    def test_no_stock_confirm_empty(self):
+        # there's no stock and no draft inventory
+        # confirm_empty should auto-validate the zero inventory
+        self.inventory.confirm_empty(self.location, self.product)
+        quants = self.quant_model._gather(self.product, self.location)
+        self.assertEqual(len(quants), 1)
+        self.assertFalse(self.inventory._inventory_exists(self.location, self.product))
+        self.assertEqual(quants.quantity, 0)
+        self.assertFalse(quants.inventory_quantity_set)
+
+    def test_no_stock_confirm_not_empty(self):
+        # there's no stock
+        # confirm not empty should create a new inventory quand with qty 1
+        self.inventory.confirm_not_empty(self.location, self.product)
+        new_quants = self._get_new_quants()
+        self.assertEqual(len(new_quants), 1)
+        self.assert_inventory_quant_zero(new_quants)
+
+    def test_stock_confirm_empty(self):
+        # There's stock
+        self._add_stock_to_product()
+        # confirm_empty should set inventory_qty to 0 on existing quants
+        self.inventory.confirm_empty(self.location, self.product)
+        new_quants = self._get_new_quants()
+        self.assertFalse(new_quants)
+        self.assertEqual(self.quants_before.inventory_quantity, 0)
+        self.assertFalse(self.quants_before.inventory_quantity_set)
+
+    def test_stock_confirm_not_empty(self):
+        # There's stock
+        self._add_stock_to_product()
+        # confirm_not_empty should set inventory qty to 1 on existing quants
+        self.inventory.confirm_not_empty(self.location, self.product)
+        new_quants = self._get_new_quants()
+        self.assertFalse(new_quants)
+        self.assert_inventory_quant_zero(self.quants_before)

--- a/shopfloor/tests/test_cluster_picking_is_zero.py
+++ b/shopfloor/tests/test_cluster_picking_is_zero.py
@@ -33,6 +33,8 @@ class ClusterPickingIsZeroCase(ClusterPickingCommonCase):
 
         cls.line = cls.picking.move_line_ids[0]
         cls.next_line = cls.picking.move_line_ids[1]
+        cls.line.location_id = cls.shelf1
+        cls.next_line.location_id = cls.shelf2
         cls.bin1 = cls.env["stock.quant.package"].create({})
         cls._update_qty_in_location(
             cls.line.location_id, cls.line.product_id, cls.line.quantity

--- a/shopfloor/tests/test_zone_picking_zero_check.py
+++ b/shopfloor/tests/test_zone_picking_zero_check.py
@@ -30,6 +30,7 @@ class ZonePickingZeroCheckCase(ZonePickingCommonCase):
         zone_location = self.zone_location
         picking_type = self.picking1.picking_type_id
         move_line = self.picking1.move_line_ids[0]
+        move_line.location_id = self.shelf1
         response = self.service.dispatch(
             "is_zero",
             params={"move_line_id": move_line.id, "zero": True},


### PR DESCRIPTION
Zero checks are triggered when odoo thinks stock for a location is 0 after an operation.
When user clicks on `location not empty`, it creates a draft inventory.
When user clicks on `location empty`, nothing happens, as we assume there's nothing to do when counted qty is right.

This PR creates an inventory with `inventory_quantity` with qty = 0 or 1 depending on whether user clicked on `location empty` or `location not empty`.