### PR TITLE
[18.0][FIX] shopfloor: fix checkout scan document crash 

### DIFF
--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -308,7 +308,9 @@ class Checkout(Component):
         # where qty >= packaging.qty, since it doesn't makes sense
         # to select a move line which have less qty than the packaging
         line_domain = [("quantity", ">=", packaging.qty)]
-        return self._select_document_from_product(product, line_domain=line_domain)
+        return self._select_document_from_product(
+            product, line_domain=line_domain, **kw
+        )
 
     def _select_document_from_none(self, *args, barcode=None, **kwargs):
         """Handle result when no record is found."""

--- a/shopfloor/tests/test_checkout_scan.py
+++ b/shopfloor/tests/test_checkout_scan.py
@@ -54,6 +54,20 @@ class CheckoutScanCase(CheckoutCommonCase):
             in_package=False,
         )
 
+    def test_scan_document_error_packaging_without_transfer(self):
+        response = self.service.dispatch(
+            "scan_document", params={"barcode": self.product_c_packaging.barcode}
+        )
+        self.assert_response(
+            response,
+            next_state="select_document",
+            message={
+                "message_type": "error",
+                "body": "No transfer found for packaging Box",
+            },
+            data={"restrict_scan_first": False},
+        )
+
     def test_scan_document_error_not_found(self):
         response = self.service.dispatch("scan_document", params={"barcode": "NOPE"})
         self.assert_response(


### PR DESCRIPTION
Fix missing return parameters
```
Traceback (most recent call last):
  File "/odoo/external-src/rest-framework/rest_log/components/service.py", line 53, in _dispatch_with_db_logging
    result = super().dispatch(method_name, *args, params=params)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/rest-framework/base_rest/components/service.py", line 161, in dispatch
    res = method(*args, **secure_params)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/rest-framework/base_rest/restapi.py", line 104, in response_wrap
    response = f(*args, **kw)
               ^^^^^^^^^^^^^^
  File "/odoo/external-src/stock-logistics-shopfloor/shopfloor/services/checkout.py", line 239, in scan_document
    return handler(search_result.record, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/stock-logistics-shopfloor/shopfloor/services/checkout.py", line 311, in _select_document_from_packaging
    return self._select_document_from_product(product, line_domain=line_domain)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/stock-logistics-shopfloor/shopfloor/services/checkout.py", line 302, in _select_document_from_product
    return self._select_document_from_picking(picking, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/stock-logistics-shopfloor/shopfloor/services/checkout.py", line 326, in _select_document_from_picking
    message = self.msg_store.transfer_not_found_for_record(scanned_record)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/external-src/stock-logistics-shopfloor/shopfloor/actions/message.py", line 521, in transfer_not_found_for_record
    model_name = model_mapping.get(record._name)
                                   ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_name'
```