### PR TITLE
[18.0][FIX] shopfloor_reception: fix scan lot domain

### DIFF
--- a/shopfloor_reception/services/reception.py
+++ b/shopfloor_reception/services/reception.py
@@ -125,8 +125,8 @@ class Reception(Component):
             ("move_id.picking_id.state", "=", "assigned"),
             ("move_id.picking_id.user_id", "=", False),
             "|",
-            ("lot_id.name", "=", lot),
-            ("lot_name", "=", lot),
+            ("lot_id", "=", lot.id),
+            ("lot_name", "=", lot.name),
         ]
 
     def _domain_stock_picking(self, today_only=False):

--- a/shopfloor_reception/tests/test_select_document.py
+++ b/shopfloor_reception/tests/test_select_document.py
@@ -178,3 +178,35 @@ class TestSelectDocument(CommonCase):
             data={"pickings": self._data_for_pickings(picking)},
             message=message,
         )
+
+    def test_scan_lot_1(self):
+        picking = self._create_picking()
+        lot = self._create_lot()
+        line_product_a = picking.move_ids.move_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        line_product_a.lot_id = lot
+        response = self.service.dispatch("scan_document", params={"barcode": lot.name})
+        body = "Several transfers found, please select a transfer manually."
+        self.assert_response(
+            response,
+            next_state="select_document",
+            data={"pickings": self._data_for_pickings(picking)},
+            message={"message_type": "error", "body": body},
+        )
+
+    def test_scan_lot_2(self):
+        picking = self._create_picking()
+        lot = self._create_lot()
+        line_product_a = picking.move_ids.move_line_ids.filtered(
+            lambda line: line.product_id == self.product_a
+        )
+        line_product_a.lot_name = lot.name
+        response = self.service.dispatch("scan_document", params={"barcode": lot.name})
+        body = "Several transfers found, please select a transfer manually."
+        self.assert_response(
+            response,
+            next_state="select_document",
+            data={"pickings": self._data_for_pickings(picking)},
+            message={"message_type": "error", "body": body},
+        )


### PR DESCRIPTION
Fix for this stack trace
```
...
  File "/odoo/src/odoo/osv/expression.py", line 1459, in parse
    push_result(model._condition_to_sql(alias, left, operator, right, self.query))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/odoo/src/odoo/models.py", line 3150, in _condition_to_sql
    assert not isinstance(value, BaseModel), \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Invalid value stock.lot(126774,) in domain term ('name', '=', stock.lot(126774,))
```