### PR TITLE
[18.0][FIX] shopfloor: fix cluster picking scan destination

### DIFF
--- a/shopfloor/services/cluster_picking.py
+++ b/shopfloor/services/cluster_picking.py
@@ -1464,7 +1464,6 @@ class ShopfloorClusterPickingValidator(Component):
             "quantity": {
                 "coerce": to_float,
                 "required": True,
-                "nullable": True,
                 "type": "float",
             },
         }

--- a/shopfloor/tests/test_cluster_picking_scan_destination.py
+++ b/shopfloor/tests/test_cluster_picking_scan_destination.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo import exceptions
+
 from .test_cluster_picking_base import ClusterPickingCommonCase
 
 # pylint: disable=missing-return
@@ -212,6 +214,20 @@ class ClusterPickingScanDestinationPackCase(ClusterPickingCommonCase):
                 "body": "Bin {} doesn't exist".format("⌿"),
             },
         )
+
+    def test_scan_destination_pack_quantity_none(self):
+        """Scan destination package do not allow quantity set to None."""
+        line = self.one_line_picking.move_line_ids
+        with self.assertRaises(exceptions.UserError):
+            self.service.dispatch(
+                "scan_destination_pack",
+                params={
+                    "picking_batch_id": self.batch.id,
+                    "move_line_id": line.id,
+                    "barcode": self.bin1.name,
+                    "quantity": None,
+                },
+            )
 
     def test_scan_destination_pack_quantity_more(self):
         """Pick more units than expected"""


### PR DESCRIPTION
The `quantity` parameter for `scan_destination_pack` allows null values, but then calls `_split_qty_to_be_done` without intializing the quantity value.
And the endpoint crashes.

This changes makes the quantity parameter required for the endpoint, to see if it is a viable solution.