### PR TITLE
[18.0][IMP] shopfloor_single_product_transfer: Improve lot scan uniqueness o…

### DIFF
--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -845,16 +845,29 @@ class ShopfloorSingleProductTransfer(Component):
         package = self.env["stock.quant.package"].browse(package_id)
         if not location.exists() and not package.exists():
             return self._response_for_select_location_or_package()
+        products = (
+            self.env["stock.quant"]
+            .search([("location_id", "=", location.id or package.location_id.id)])
+            .product_id
+        )
         handlers_by_type = {
             "product": self._scan_product__scan_product,
             "packaging": self._scan_product__scan_packaging,
             "lot": self._scan_product__scan_lot,
         }
         search = self._actions_for("search")
-        search_result = search.find(barcode, types=handlers_by_type.keys())
+        search_result = search.find(
+            barcode,
+            types=handlers_by_type.keys(),
+            handler_kw={"lot": {"products": products}},
+        )
         handler = handlers_by_type.get(search_result.type)
         if handler:
-            return handler(search_result.record, location=location, package=package)
+            return handler(
+                search_result.record,
+                location=location,
+                package=package,
+            )
         message = self.msg_store.barcode_not_found()
         return self._response_for_select_product(
             location=location, package=package, message=message

--- a/shopfloor_single_product_transfer/tests/test_scan_product.py
+++ b/shopfloor_single_product_transfer/tests/test_scan_product.py
@@ -255,7 +255,7 @@ class TestScanProduct(CommonCase):
             self.assertIn(ROLLBACK_LOG, log_catcher.output)
         expected_message = {
             "message_type": "error",
-            "body": "No operation found for this menu and profile.",
+            "body": "Barcode not found",
         }
         data = {"location": self._data_for_location(location)}
         self.assert_response(
@@ -263,6 +263,14 @@ class TestScanProduct(CommonCase):
         )
 
     def test_scan_lot_with_move_line(self):
+        # create a duplicate lot to ensure that the search
+        # on lot name is restricted to the products of the location
+        self._set_product_tracking_by_lot(self.product_b)
+        duplicate_lot = self._create_lot_for_product(self.product_b, "LOT_BARCODE")
+        self._add_stock_to_product(
+            self.product_b, self.location_dest, 10, lot=duplicate_lot
+        )
+
         location = self.location_src
         product = self.product_a
         self._set_product_tracking_by_lot(product)


### PR DESCRIPTION
…n location

Before this commit, when scanning a lot for a single product transfer, the system searched for the lot name without restricting it to the products available in the scanned location. This could lead to issues when there were multiple lots with the same name in different locations.

With this commit, the search for the lot name is now restricted to the products available in the scanned location. This ensures that the correct lot is identified during the scanning process, even if there are duplicate lot names in different locations. (At least if products in the location doesn't share lot names, but at least it reduces the risk of picking the wrong lot)