### PR TITLE
[IMP] shopfloor: remove dependency on stock_location_is_sublocation

### DIFF
--- a/shopfloor/__manifest__.py
+++ b/shopfloor/__manifest__.py
@@ -22,7 +22,6 @@
         "base_rest",
         "base_sparse_field",
         #  OCA / stock-logistics-warehouse
-        "stock_location_is_sublocation",
         "stock_picking_completion_info",
         #  OCA / stock-logistics-workflow
         "stock_move_line_change_lot",

--- a/shopfloor/services/delivery.py
+++ b/shopfloor/services/delivery.py
@@ -187,9 +187,7 @@ class Delivery(Component):
         return self._deliver_lot(picking, lot, product_qty=1, location=location)
 
     def _scan_deliver__by_location(self, scanned_location, picking, location):
-        if scanned_location.is_sublocation_of(
-            self.picking_types.mapped("default_location_src_id")
-        ):
+        if self.is_src_location_valid(scanned_location):
             message = self.msg_store.location_src_set_to_sublocation(scanned_location)
             return self._response_for_deliver(
                 location=scanned_location, message=message

--- a/shopfloor/services/service.py
+++ b/shopfloor/services/service.py
@@ -130,29 +130,32 @@ class BaseShopfloorProcess(AbstractComponent):
         We ensure the source is valid regarding one of the picking types of the
         process.
         """
-        return location.is_sublocation_of(self.picking_types.default_location_src_id)
+        return any(
+            location._child_of(src)
+            for src in self.picking_types.default_location_src_id
+        )
 
     def is_dest_location_valid(self, moves, location):
         """Check the destination location is valid for given moves.
 
         We ensure the destination is either valid regarding the picking
         destination location or the move destination location. With the push
-        rules in the module stock_dynamic_routing in OCA/wms, it is possible
-        that the move destination is not anymore a child of the picking default
-        destination (as it is the last pushed move that now respects this
-        condition and not anymore this one that has a destination to an
-        intermediate location)
+        rules in the module stock_dynamic_routing in
+        OCA/stock-logistics-workflow, it is possible that the move destination
+        is not anymore a child of the picking default destination (as it is the
+        last pushed move that now respects this condition and not anymore this
+        one that has a destination to an intermediate location)
         """
-        return location.is_sublocation_of(
-            moves.picking_id.location_dest_id, func=all
-        ) or location.is_sublocation_of(moves.location_dest_id, func=all)
+        return all(
+            location._child_of(dest) for dest in moves.picking_id.location_dest_id
+        ) or all(location._child_of(dest) for dest in moves.location_dest_id)
 
     def is_dest_location_to_confirm(self, location_dest_id, location):
         """Check the destination location requires confirmation
 
         The location is valid but not the expected one: ask for confirmation
         """
-        return not location.is_sublocation_of(location_dest_id)
+        return not location._child_of(location_dest_id)
 
     def is_allow_move_create(self):
         """Check a new operation can be created

--- a/shopfloor/services/zone_picking.py
+++ b/shopfloor/services/zone_picking.py
@@ -547,7 +547,7 @@ class ZonePicking(Component):
         if not location:
             return response, message
 
-        if not location.is_sublocation_of(self.zone_location):
+        if not location._child_of(self.zone_location):
             response = self._list_move_lines(self.zone_location)
             message = self.msg_store.location_not_allowed()
             return response, message
@@ -623,7 +623,7 @@ class ZonePicking(Component):
         if not package:
             return response, message
         if package.location_id:
-            if not package.location_id.is_sublocation_of(self.zone_location):
+            if not package.location_id._child_of(self.zone_location):
                 # Package is not in an allowed location
                 response = self._list_move_lines(self.zone_location)
                 message = self.msg_store.location_not_allowed()


### PR DESCRIPTION
Use location._child_of method introduced in odoo v16.0

Drop dependency on stock_location_is_sublocation

cc @TDu @mmequignon @simahawk @rousseldenis @lmignon