### PR TITLE
[18.0][IMP] shopfloor_single_product_transfer: Back to select_location_or_p…

### DIFF
--- a/shopfloor_single_product_transfer/services/single_product_transfer.py
+++ b/shopfloor_single_product_transfer/services/single_product_transfer.py
@@ -70,8 +70,10 @@ class ShopfloorSingleProductTransfer(Component):
 
     # Responses
 
-    def _response_for_select_location_or_package(self, message=None):
-        return self._response(next_state="select_location_or_package", message=message)
+    def _response_for_select_location_or_package(self, message=None, popup=None):
+        return self._response(
+            next_state="select_location_or_package", message=message, popup=popup
+        )
 
     def _response_for_select_product(
         self,
@@ -649,6 +651,19 @@ class ShopfloorSingleProductTransfer(Component):
         if unload:
             lines.result_package_id = False
 
+    def _has_pending_operations_at_same_location(self, move_line):
+        return bool(
+            self.env["stock.move.line"].search_count(
+                [
+                    ("state", "in", ("assigned", "partially_available")),
+                    ("location_id", "=", move_line.location_id.id),
+                    ("picking_id.picking_type_id", "in", self.picking_types.ids),
+                    ("id", "!=", move_line.id),
+                ],
+                limit=1,
+            )
+        )
+
     def _set_quantity__post_move(self, move_line, location, confirmation=None):
         # TODO still valid ?
         # TODO qty_done = 0: transfer_no_qty_done
@@ -663,6 +678,13 @@ class ShopfloorSingleProductTransfer(Component):
         message = self.msg_store.transfer_done_success(move_line.picking_id)
         completion_info = self._actions_for("completion.info")
         completion_info_popup = completion_info.popup(move_line)
+        if (
+            not self.is_allow_move_create()
+            and not self._has_pending_operations_at_same_location(move_line)
+        ):
+            return self._response_for_select_location_or_package(
+                message=message, popup=completion_info_popup
+            )
         return self._response_for_select_product(
             location=move_line.location_id,
             package=move_line.package_id,

--- a/shopfloor_single_product_transfer/tests/test_set_location.py
+++ b/shopfloor_single_product_transfer/tests/test_set_location.py
@@ -40,12 +40,10 @@ class TestSetLocation(CommonCase):
         expected_message = self.msg_store.transfer_done_success(move_line.picking_id)
         completion_info = self.service._actions_for("completion.info")
         expected_popup = completion_info.popup(move_line)
-        data = {"location": self._data_for_location(self.location)}
         self.assert_response(
             response,
-            next_state="select_product",
+            next_state="select_location_or_package",
             message=expected_message,
-            data=data,
             popup=expected_popup,
         )
 

--- a/shopfloor_single_product_transfer/tests/test_set_quantity.py
+++ b/shopfloor_single_product_transfer/tests/test_set_quantity.py
@@ -556,9 +556,58 @@ class TestSetQuantity(CommonCase):
         expected_message = self.service.msg_store.transfer_done_success(
             move_line.picking_id
         )
-        data = {"location": self._data_for_location(location)}
+        self.assert_response(
+            response, next_state="select_location_or_package", message=expected_message
+        )
+
+    def test_set_quantity_multi_operation_same_location(self):
+        self._add_stock_to_product(self.product, self.location, 10)
+        self._add_stock_to_product(self.product_b, self.location, 10)
+        picking = self._create_picking(lines=[(self.product, 10), (self.product_b, 10)])
+
+        location = self.location
+
+        move_line = picking.move_line_ids.filtered(
+            lambda ml: ml.product_id == self.product
+        )
+        self.service.dispatch(
+            "scan_product",
+            params={"location_id": location.id, "barcode": self.product.barcode},
+        )
+        params = {
+            "selected_line_id": move_line.id,
+            "quantity": move_line.qty_picked,
+            "barcode": self.dispatch_location.barcode,
+        }
+        response = self.service.dispatch("set_quantity", params=params)
+        expected_message = self.service.msg_store.transfer_done_success(
+            move_line.picking_id
+        )
+        data = {
+            "location": self._data_for_location(location),
+        }
         self.assert_response(
             response, next_state="select_product", message=expected_message, data=data
+        )
+
+        move_line = picking.move_line_ids.filtered(
+            lambda ml: ml.product_id == self.product_b
+        )
+        self.service.dispatch(
+            "scan_product",
+            params={"location_id": location.id, "barcode": self.product_b.barcode},
+        )
+        params = {
+            "selected_line_id": move_line.id,
+            "quantity": move_line.qty_picked,
+            "barcode": self.dispatch_location.barcode,
+        }
+        response = self.service.dispatch("set_quantity", params=params)
+        expected_message = self.service.msg_store.transfer_done_success(
+            move_line.picking_id
+        )
+        self.assert_response(
+            response, next_state="select_location_or_package", message=expected_message
         )
 
     def test_set_quantity_confirm_with_different_barcode(self):
@@ -592,9 +641,8 @@ class TestSetQuantity(CommonCase):
         expected_message = self.service.msg_store.transfer_done_success(
             move_line.picking_id
         )
-        data = {"location": self._data_for_location(self.location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response, next_state="select_location_or_package", message=expected_message
         )
 
     def test_set_quantity_child_move_location(self):
@@ -615,9 +663,8 @@ class TestSetQuantity(CommonCase):
             },
         )
         expected_message = self.msg_store.transfer_done_success(move_line.picking_id)
-        data = {"location": self._data_for_location(location)}
         self.assert_response(
-            response, next_state="select_product", message=expected_message, data=data
+            response, next_state="select_location_or_package", message=expected_message
         )
 
     def test_action_cancel(self):
@@ -694,12 +741,10 @@ class TestSetQuantity(CommonCase):
         expected_message = self.msg_store.transfer_done_success(move_line.picking_id)
         completion_info = self.service._actions_for("completion.info")
         expected_popup = completion_info.popup(move_line)
-        data = {"location": self._data_for_location(location)}
         self.assert_response(
             response,
-            next_state="select_product",
+            next_state="select_location_or_package",
             message=expected_message,
-            data=data,
             popup=expected_popup,
         )
 
@@ -813,16 +858,12 @@ class TestSetQuantity(CommonCase):
                 "barcode": package.name,
             },
         )
-        expected_data = {
-            "location": self._data_for_location(self.location),
-        }
         expected_message = self.msg_store.transfer_done_success(move_line.picking_id)
         completion_info = self.service._actions_for("completion.info")
         expected_popup = completion_info.popup(move_line)
         self.assert_response(
             response,
-            next_state="select_product",
-            data=expected_data,
+            next_state="select_location_or_package",
             message=expected_message,
             popup=expected_popup,
         )

--- a/shopfloor_single_product_transfer/tests/test_set_quantity_checkout_sync.py
+++ b/shopfloor_single_product_transfer/tests/test_set_quantity_checkout_sync.py
@@ -80,14 +80,12 @@ class TestSetQuantityCheckoutSync(CommonCase):
             },
         )
         expected_message = self.msg_store.transfer_done_success(move_line.picking_id)
-        data = {"location": self._data_for_location(self.location)}
         completion_info = self.service._actions_for("completion.info")
         expected_popup = completion_info.popup(move_line)
         self.assert_response(
             response,
-            next_state="select_product",
+            next_state="select_location_or_package",
             message=expected_message,
-            data=data,
             popup=expected_popup,
         )
         self.assertEqual(move1.move_line_ids.location_dest_id, self.dispatch_location)


### PR DESCRIPTION
…ackage

When the user sets a location for a move line, we used to go back to the select_product state. This is not ideal in the case where the no more product needs to be selected at the current location (no more pending move line at this location), as the user would have to select a new location to be able to select the next move line.

Now, if the scenario is configured to forbid the creation of new move lines and there is no more pending move line at the current location, when the user sets a location for a move line, the next state will be select_location_or_package instead of select_product.