### PR TITLE
[WIP][FIX] shopfloor: enforce constraints

### DIFF
--- a/shopfloor/models/shopfloor_menu.py
+++ b/shopfloor/models/shopfloor_menu.py
@@ -392,6 +392,21 @@ class ShopfloorMenu(models.Model):
                     _("Creation of moves is not allowed for menu {}.").format(menu.name)
                 )
 
+    @api.constrains(
+        "scenario_id", "picking_type_ids", "unload_package_at_destination"
+    )
+    def _check_unload_package_at_destination(self):
+        for menu in self:
+            if (
+                menu.unload_package_at_destination
+                and not menu.unload_package_at_destination_is_possible
+            ):
+                raise exceptions.ValidationError(
+                    _("Unload package at destination is not allowed for menu {}.").format(
+                        menu.name
+                    )
+                )
+
     @api.depends("scenario_id")
     def _compute_unreserve_other_moves_is_possible(self):
         for menu in self:


### PR DESCRIPTION
The following fields are paired but no constraint enforces them.

| Option field                            | `_is_possible` flag                                 |
| --------------------------------------- | --------------------------------------------------- |
| `allow_unreserve_other_moves`           | `unreserve_other_moves_is_possible`                 |
| `ignore_no_putaway_available`           | `ignore_no_putaway_available_is_possible`           |
| `allow_prepackaged_product`             | `prepackaged_product_is_possible`                   |
| `pick_pack_same_time`                   | `pick_pack_same_time_is_possible`                   |
| `multiple_move_single_pack`             | `multiple_move_single_pack_is_possible`             |
| `disable_full_bin_action`               | `disable_full_bin_action_is_possible`               |
| `allow_force_reservation`               | `allow_force_reservation_is_possible`               |
| `allow_get_work`                        | `allow_get_work_is_possible`                        |
| `no_prefill_qty`                        | `no_prefill_qty_is_possible`                        |
| `show_oneline_package_content`          | `show_oneline_package_content_is_possible`          |
| `scan_location_or_pack_first`           | `scan_location_or_pack_first_is_possible`           |
| `allow_alternative_destination`         | `allow_alternative_destination_is_possible`         |
| `allow_return`                          | `allow_return_is_possible`                          |
| `auto_post_line`                        | `auto_post_line_is_possible`                        |
| `allow_alternative_destination_package` | `allow_alternative_destination_package_is_possible` |
| `require_destination_package`           | `require_destination_package_is_possible`           |
| `move_line_search_additional_domain`    | `move_line_search_additional_domain_is_possible`    |
| `move_line_search_sort_order`           | `move_line_search_sort_order_is_possible`           |
| `move_line_processing_sort_order`       | `move_line_processing_sort_order_is_possible`       |

Also, if `_is_possible` field switch back to false, nothing revert the corresponding option.