### PR TITLE
[FIX] shopfloor_cluster_picking_repack_mobile: Use correct data member for scan_package_action()

### DIFF
--- a/shopfloor_cluster_picking_repack_mobile/static/src/js/cluster_picking.esm.js
+++ b/shopfloor_cluster_picking_repack_mobile/static/src/js/cluster_picking.esm.js
@@ -334,7 +334,7 @@ const data = function () {
             const data = this.state.data;
             this.wait_call(
                 this.odoo.call("scan_package_action", {
-                    picking_id: data.id,
+                    picking_id: data.picking.id,
                     selected_line_ids: this.selected_line_ids(),
                     barcode: scanned.text,
                 })


### PR DESCRIPTION
Forward port from:
* https://github.com/OCA/wms/pull/718/commits

cc @rousseldenis 