### PR TITLE
[FIX] shopfloor: checkout: do not hide functional errors

### DIFF
--- a/shopfloor/actions/message.py
+++ b/shopfloor/actions/message.py
@@ -431,12 +431,6 @@ class MessageAction(Component):
             "body": _("Transfer {} is not available.").format(picking.name),
         }
 
-    def move_validation_failed(self, exception):
-        return {
-            "message_type": "error",
-            "body": _("Move validation failed. %s") % str(exception),
-        }
-
     def line_has_package_scan_package(self):
         return {
             "message_type": "warning",

--- a/shopfloor/services/checkout.py
+++ b/shopfloor/services/checkout.py
@@ -2,8 +2,6 @@
 # Copyright 2020 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-import logging
-
 from werkzeug.exceptions import BadRequest
 
 from odoo import _, fields
@@ -12,8 +10,6 @@ from odoo.addons.base_rest.components.service import to_int
 from odoo.addons.component.core import Component
 
 from ..utils import to_float
-
-_logger = logging.getLogger(__name__)
 
 
 class Checkout(Component):
@@ -1566,21 +1562,7 @@ class Checkout(Component):
                 picking,
             )
         stock = self._actions_for("stock")
-        savepoint = self._actions_for("savepoint").new()
-        try:
-            stock.validate_moves(lines_done.move_id)
-        except Exception as e:
-            savepoint.rollback()
-            _logger.error("Error while validating moves: %s", e)
-            # in case of error, go back to the location selection and pass the error
-            # to the user. This is to fix issue where user only saw a generic
-            # server error when validation failed with external API
-            return self._response_for_summary(
-                picking,
-                need_confirm=False,
-                message=self.msg_store.move_validation_failed(e),
-            )
-        savepoint.release()
+        stock.validate_moves(lines_done.move_id)
         return self._response_for_select_document(
             message=self.msg_store.transfer_done_success(lines_done.picking_id)
         )
@@ -1618,20 +1600,7 @@ class Checkout(Component):
         for line in lines_done:
             line.update({"location_dest_id": scanned_location.id})
         stock = self._actions_for("stock")
-        savepoint = self._actions_for("savepoint").new()
-        try:
-            stock.validate_moves(lines_done.move_id)
-        except Exception as e:
-            savepoint.rollback()
-            _logger.error("Error while validating moves: %s", e)
-            # in case of error, go back to the location selection and pass the error
-            # to the user. This is to fix issue where user only saw a generic
-            # server error when validation failed with external API
-            return self._response_for_select_child_location(
-                picking,
-                message=self.msg_store.move_validation_failed(e),
-            )
-        savepoint.release()
+        stock.validate_moves(lines_done.move_id)
         return self._response_for_select_document(
             message=self.msg_store.transfer_done_success(lines_done.picking_id)
         )

--- a/shopfloor/tests/test_checkout_done.py
+++ b/shopfloor/tests/test_checkout_done.py
@@ -1,13 +1,5 @@
 # Copyright 2020 Camptocamp SA (http://www.camptocamp.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from unittest.mock import patch
-
-from werkzeug.exceptions import BadRequest
-
-from odoo.tools import mute_logger
-
-from odoo.addons.shopfloor.actions.stock import StockAction
-
 from .test_checkout_base import CheckoutCommonCase
 
 
@@ -32,31 +24,6 @@ class CheckoutDoneCase(CheckoutCommonCase):
             },
             data={"restrict_scan_first": False},
         )
-
-    @mute_logger("odoo.addons.shopfloor.services.checkout")
-    def test_done_validation_error(self):
-        picking = self._create_picking(lines=[(self.product_a, 10)])
-        self._fill_stock_for_moves(picking.move_ids, in_package=True)
-        picking.action_assign()
-        # line is done
-        picking.move_line_ids.write({"qty_picked": 10, "shopfloor_checkout_done": True})
-
-        # mock validation error in stock.validate_moves
-        validation_error_msg = "Validation error"
-        with patch.object(
-            StockAction, "validate_moves", side_effect=BadRequest(validation_error_msg)
-        ):
-            response = self.service.dispatch("done", params={"picking_id": picking.id})
-            self.assert_response(
-                response,
-                next_state="summary",
-                message={
-                    "message_type": "error",
-                    "body": f"\
-Move validation failed. 400 Bad Request: {validation_error_msg}",
-                },
-                data=self.ANY,
-            )
 
 
 class CheckoutDonePartialCase(CheckoutCommonCase):

--- a/shopfloor/tests/test_checkout_scan_dest_location.py
+++ b/shopfloor/tests/test_checkout_scan_dest_location.py
@@ -3,14 +3,6 @@
 
 # pylint: disable=missing-return
 
-from unittest.mock import patch
-
-from werkzeug.exceptions import BadRequest
-
-from odoo.tools import mute_logger
-
-from odoo.addons.shopfloor.actions.stock import StockAction
-
 from .test_checkout_base import CheckoutCommonCase
 
 
@@ -105,29 +97,3 @@ class CheckoutSelectChildLocationCase(CheckoutCommonCase):
             },
             message=self.service.msg_store.dest_location_not_allowed(),
         )
-
-    @mute_logger("odoo.addons.shopfloor.services.checkout")
-    def test_scan_dest_location_validation_error(self):
-        validation_error_msg = "Validation error"
-        with patch.object(
-            StockAction,
-            "validate_moves",
-            side_effect=BadRequest(validation_error_msg),
-        ):
-            response = self.service.dispatch(
-                "scan_dest_location",
-                params={
-                    "picking_id": self.picking.id,
-                    "barcode": self.child_location.name,
-                },
-            )
-            self.assert_response(
-                response,
-                next_state="select_child_location",
-                message={
-                    "message_type": "error",
-                    "body": f"\
-Move validation failed. 400 Bad Request: {validation_error_msg}",
-                },
-                data=self.ANY,
-            )


### PR DESCRIPTION
This reverts commit 9e4f1874ccc8eb0f6f743520d26597cadd713140.

Revert of:
* https://github.com/OCA/stock-logistics-shopfloor/pull/71

Functional Errors should be raised as error in order to have them logged as such in REST logs.

cc @henrybackman @simahawk @sebalix 